### PR TITLE
feat: add possibility to users to have their custom configuration for opencode

### DIFF
--- a/playbooks/roles/packages/tasks/ai.yml
+++ b/playbooks/roles/packages/tasks/ai.yml
@@ -69,57 +69,50 @@
         path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
       register: sparkdock_opencode_config_stat
 
+    - name: Set opencode base config path from sparkdock
+      ansible.builtin.set_fact:
+        opencode_base_config_path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
+      when: sparkdock_opencode_config_stat.stat.exists == true
+
+    - name: Set opencode base config path from bundled fallback
+      ansible.builtin.set_fact:
+        opencode_base_config_path: "{{ role_path }}/files/opencode/opencode.json"
+      when: sparkdock_opencode_config_stat.stat.exists == false
+
     - name: Check if opencode local override file exists
       ansible.builtin.stat:
         path: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
       register: opencode_local_config_stat
 
-    - name: Read sparkdock opencode config
+    - name: Read opencode base config
       ansible.builtin.slurp:
-        src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
-      register: sparkdock_opencode_config_content
+        src: "{{ opencode_base_config_path }}"
+      register: opencode_base_config_content
       no_log: true
-      when:
-        - sparkdock_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat.stat.exists == true
+      when: opencode_local_config_stat.stat.exists == true
 
     - name: Read opencode local override file
       ansible.builtin.slurp:
         src: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
       register: opencode_local_config_content
       no_log: true
-      when:
-        - sparkdock_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat.stat.exists == true
+      when: opencode_local_config_stat.stat.exists == true
 
     - name: Write merged opencode config with local overrides
       ansible.builtin.copy:
-        content: "{{ (sparkdock_opencode_config_content.content | b64decode | from_json) | combine(opencode_local_config_content.content | b64decode | from_json, recursive=True) | to_nice_json }}\n"
+        content: "{{ (opencode_base_config_content.content | b64decode | from_json) | combine(opencode_local_config_content.content | b64decode | from_json, recursive=True) | to_nice_json }}\n"
         dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
       no_log: true
-      when:
-        - sparkdock_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat.stat.exists == true
+      when: opencode_local_config_stat.stat.exists == true
 
-    - name: Copy opencode config file from sparkdock (no local overrides)
+    - name: Copy opencode base config file (no local overrides)
       ansible.builtin.copy:
-        src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
+        src: "{{ opencode_base_config_path }}"
         dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
-      when:
-        - sparkdock_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat.stat.exists == false
-
-    - name: Create opencode config file as fallback if it doesn't exist from sparkdock
-      ansible.builtin.copy:
-        dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
-        src: "files/opencode/opencode.json"
-        mode: "0644"
-        owner: "{{ system.username | default(current_user) }}"
-        group: "{{ system.username | default(current_user) }}"
-      when: not sparkdock_opencode_config_stat.stat.exists
+      when: opencode_local_config_stat.stat.exists == false

--- a/playbooks/roles/packages/tasks/ai.yml
+++ b/playbooks/roles/packages/tasks/ai.yml
@@ -78,6 +78,7 @@
       ansible.builtin.slurp:
         src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
       register: sparkdock_opencode_config_content
+      no_log: true
       when:
         - sparkdock_opencode_config_stat.stat.exists == true
         - opencode_local_config_stat.stat.exists == true
@@ -86,6 +87,7 @@
       ansible.builtin.slurp:
         src: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
       register: opencode_local_config_content
+      no_log: true
       when:
         - sparkdock_opencode_config_stat.stat.exists == true
         - opencode_local_config_stat.stat.exists == true
@@ -97,6 +99,7 @@
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
+      no_log: true
       when:
         - sparkdock_opencode_config_stat.stat.exists == true
         - opencode_local_config_stat.stat.exists == true

--- a/playbooks/roles/packages/tasks/ai.yml
+++ b/playbooks/roles/packages/tasks/ai.yml
@@ -69,14 +69,48 @@
         path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
       register: sparkdock_opencode_config_stat
 
-    - name: Copy opencode config file from sparkdock if it exists
+    - name: Check if opencode local override file exists
+      ansible.builtin.stat:
+        path: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
+      register: opencode_local_config_stat
+
+    - name: Read sparkdock opencode config
+      ansible.builtin.slurp:
+        src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
+      register: sparkdock_opencode_config_content
+      when:
+        - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat.stat.exists == true
+
+    - name: Read opencode local override file
+      ansible.builtin.slurp:
+        src: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
+      register: opencode_local_config_content
+      when:
+        - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat.stat.exists == true
+
+    - name: Write merged opencode config with local overrides
+      ansible.builtin.copy:
+        content: "{{ (sparkdock_opencode_config_content.content | b64decode | from_json) | combine(opencode_local_config_content.content | b64decode | from_json, recursive=True) | to_nice_json }}\n"
+        dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
+        mode: "0644"
+        owner: "{{ system.username | default(current_user) }}"
+        group: "{{ system.username | default(current_user) }}"
+      when:
+        - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat.stat.exists == true
+
+    - name: Copy opencode config file from sparkdock (no local overrides)
       ansible.builtin.copy:
         src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
         dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
-      when: sparkdock_opencode_config_stat.stat.exists
+      when:
+        - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat.stat.exists == false
 
     - name: Create opencode config file as fallback if it doesn't exist from sparkdock
       ansible.builtin.copy:

--- a/playbooks/roles/sparkdock/files/opencode/opencode.json
+++ b/playbooks/roles/sparkdock/files/opencode/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "disabled_providers": ["opencode"]
+}

--- a/playbooks/roles/sparkdock/tasks/main.yml
+++ b/playbooks/roles/sparkdock/tasks/main.yml
@@ -43,7 +43,43 @@
         path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
       register: sparkdock_opencode_config_stat
 
-    - name: Copy opencode config file from sparkdock if the opencode config directory exists
+    - name: Check if opencode local override file exists
+      ansible.builtin.stat:
+        path: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
+      register: opencode_local_config_stat
+      when: home_opencode_config_stat.stat.exists == true
+
+    - name: Read sparkdock opencode config
+      ansible.builtin.slurp:
+        src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
+      register: sparkdock_opencode_config_content
+      when:
+        - home_opencode_config_stat.stat.exists == true
+        - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat.stat.exists == true
+
+    - name: Read opencode local override file
+      ansible.builtin.slurp:
+        src: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
+      register: opencode_local_config_content
+      when:
+        - home_opencode_config_stat.stat.exists == true
+        - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat.stat.exists == true
+
+    - name: Write merged opencode config with local overrides
+      ansible.builtin.copy:
+        content: "{{ (sparkdock_opencode_config_content.content | b64decode | from_json) | combine(opencode_local_config_content.content | b64decode | from_json, recursive=True) | to_nice_json }}\n"
+        dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
+        mode: "0644"
+        owner: "{{ system.username | default(current_user) }}"
+        group: "{{ system.username | default(current_user) }}"
+      when:
+        - home_opencode_config_stat.stat.exists == true
+        - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat.stat.exists == true
+
+    - name: Copy opencode config file from sparkdock (no local overrides)
       ansible.builtin.copy:
         src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
         dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
@@ -53,6 +89,7 @@
       when:
         - home_opencode_config_stat.stat.exists == true
         - sparkdock_opencode_config_stat.stat.exists == true
+        - opencode_local_config_stat is skipped or opencode_local_config_stat.stat.exists == false
 
 - name: Setup ajust (SparkJust for Linux)
   when: sparkfabrik | default(true)

--- a/playbooks/roles/sparkdock/tasks/main.yml
+++ b/playbooks/roles/sparkdock/tasks/main.yml
@@ -49,14 +49,14 @@
         opencode_base_config_path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
       when:
         - home_opencode_config_stat.stat.exists == true
-        - sparkdock_opencode_config_stat.stat.exists == true
+        - (sparkdock_opencode_config_stat.stat.exists | default(false)) == true
 
     - name: Set opencode base config path from bundled fallback
       ansible.builtin.set_fact:
         opencode_base_config_path: "{{ role_path }}/files/opencode/opencode.json"
       when:
         - home_opencode_config_stat.stat.exists == true
-        - sparkdock_opencode_config_stat is skipped or sparkdock_opencode_config_stat.stat.exists == false
+        - sparkdock_opencode_config_stat is skipped or (sparkdock_opencode_config_stat.stat.exists | default(false)) == false
 
     - name: Check if opencode local override file exists
       ansible.builtin.stat:
@@ -71,7 +71,7 @@
       no_log: true
       when:
         - home_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat.stat.exists == true
+        - opencode_local_config_stat is not skipped and (opencode_local_config_stat.stat.exists | default(false)) == true
 
     - name: Read opencode local override file
       ansible.builtin.slurp:
@@ -80,7 +80,7 @@
       no_log: true
       when:
         - home_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat.stat.exists == true
+        - opencode_local_config_stat is not skipped and (opencode_local_config_stat.stat.exists | default(false)) == true
 
     - name: Write merged opencode config with local overrides
       ansible.builtin.copy:
@@ -92,7 +92,7 @@
       no_log: true
       when:
         - home_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat.stat.exists == true
+        - opencode_local_config_stat is not skipped and (opencode_local_config_stat.stat.exists | default(false)) == true
 
     - name: Copy opencode base config file (no local overrides)
       ansible.builtin.copy:
@@ -103,7 +103,7 @@
         group: "{{ system.username | default(current_user) }}"
       when:
         - home_opencode_config_stat.stat.exists == true
-        - opencode_local_config_stat is skipped or opencode_local_config_stat.stat.exists == false
+        - opencode_local_config_stat is skipped or (opencode_local_config_stat.stat.exists | default(false)) == false
 
 - name: Setup ajust (SparkJust for Linux)
   when: sparkfabrik | default(true)

--- a/playbooks/roles/sparkdock/tasks/main.yml
+++ b/playbooks/roles/sparkdock/tasks/main.yml
@@ -42,6 +42,21 @@
       ansible.builtin.stat:
         path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
       register: sparkdock_opencode_config_stat
+      when: home_opencode_config_stat.stat.exists == true
+
+    - name: Set opencode base config path from sparkdock
+      ansible.builtin.set_fact:
+        opencode_base_config_path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
+      when:
+        - home_opencode_config_stat.stat.exists == true
+        - sparkdock_opencode_config_stat.stat.exists == true
+
+    - name: Set opencode base config path from bundled fallback
+      ansible.builtin.set_fact:
+        opencode_base_config_path: "{{ role_path }}/files/opencode/opencode.json"
+      when:
+        - home_opencode_config_stat.stat.exists == true
+        - sparkdock_opencode_config_stat is skipped or sparkdock_opencode_config_stat.stat.exists == false
 
     - name: Check if opencode local override file exists
       ansible.builtin.stat:
@@ -49,46 +64,45 @@
       register: opencode_local_config_stat
       when: home_opencode_config_stat.stat.exists == true
 
-    - name: Read sparkdock opencode config
+    - name: Read opencode base config
       ansible.builtin.slurp:
-        src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
-      register: sparkdock_opencode_config_content
+        src: "{{ opencode_base_config_path }}"
+      register: opencode_base_config_content
+      no_log: true
       when:
         - home_opencode_config_stat.stat.exists == true
-        - sparkdock_opencode_config_stat.stat.exists == true
         - opencode_local_config_stat.stat.exists == true
 
     - name: Read opencode local override file
       ansible.builtin.slurp:
         src: "{{ system.home | default(current_home) }}/.config/opencode/opencode.local.json"
       register: opencode_local_config_content
+      no_log: true
       when:
         - home_opencode_config_stat.stat.exists == true
-        - sparkdock_opencode_config_stat.stat.exists == true
         - opencode_local_config_stat.stat.exists == true
 
     - name: Write merged opencode config with local overrides
       ansible.builtin.copy:
-        content: "{{ (sparkdock_opencode_config_content.content | b64decode | from_json) | combine(opencode_local_config_content.content | b64decode | from_json, recursive=True) | to_nice_json }}\n"
+        content: "{{ (opencode_base_config_content.content | b64decode | from_json) | combine(opencode_local_config_content.content | b64decode | from_json, recursive=True) | to_nice_json }}\n"
         dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
+      no_log: true
       when:
         - home_opencode_config_stat.stat.exists == true
-        - sparkdock_opencode_config_stat.stat.exists == true
         - opencode_local_config_stat.stat.exists == true
 
-    - name: Copy opencode config file from sparkdock (no local overrides)
+    - name: Copy opencode base config file (no local overrides)
       ansible.builtin.copy:
-        src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
+        src: "{{ opencode_base_config_path }}"
         dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
       when:
         - home_opencode_config_stat.stat.exists == true
-        - sparkdock_opencode_config_stat.stat.exists == true
         - opencode_local_config_stat is skipped or opencode_local_config_stat.stat.exists == false
 
 - name: Setup ajust (SparkJust for Linux)


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add support for user-local opencode config overrides via `opencode.local.json`

- Merge base config with local overrides using recursive JSON combine

- Add bundled fallback `opencode.json` config file for sparkdock role

- Fix sparkdock task to conditionally check opencode config stat


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["opencode.local.json\n(user override)"] -- "exists?" --> B{"Local override\ncheck"}
  B -- "yes" --> C["Read base config\n(sparkdock or fallback)"]
  C -- "merge recursive" --> D["Write merged\nopencode.json"]
  B -- "no" --> E["Copy base config\nas-is"]
  F["sparkdock opencode.json"] -- "exists?" --> G{"Sparkdock config\ncheck"}
  G -- "yes" --> C
  G -- "no" --> H["files/opencode/opencode.json\n(bundled fallback)"]
  H --> C
  H --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ai.yml</strong><dd><code>Support local opencode config overrides in packages role</code>&nbsp; </dd></summary>
<hr>

playbooks/roles/packages/tasks/ai.yml

<ul><li>Replace single copy task with a multi-step config merge workflow<br> <li> Add tasks to detect and read <code>opencode.local.json</code> user override file<br> <li> Merge base config (sparkdock or bundled fallback) with local overrides <br>using <code>combine</code> filter<br> <li> Fall back to copying base config directly when no local override <br>exists</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/176/files#diff-b86a2e8b917d8238674776ed652d0d5658b155efa5529e5e78b4cb630ea41222">+36/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.yml</strong><dd><code>Support local opencode config overrides in sparkdock role</code></dd></summary>
<hr>

playbooks/roles/sparkdock/tasks/main.yml

<ul><li>Conditionally check sparkdock opencode config stat only when home <br>config dir exists<br> <li> Add tasks to detect and read <code>opencode.local.json</code> user override file<br> <li> Merge base config with local overrides using recursive JSON combine<br> <li> Add fallback copy task when no local override or sparkdock config is <br>present</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/176/files#diff-669d040e970cd0bc9b49fb2e32fc4e511c70a6e99b1749eb187900656b07af6f">+54/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>opencode.json</strong><dd><code>Add bundled fallback opencode config file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sparkdock/files/opencode/opencode.json

<ul><li>Add new bundled fallback opencode config file with schema reference<br> <li> Disable default <code>opencode</code> provider by default</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/176/files#diff-05a545851793a8516e878d77f6f5a2779abe53c70a5956dba59d6192a5389562">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

