### PR TITLE
feat: add support for installing ajust packages on Debian/Ubuntu

### DIFF
--- a/playbooks/roles/docker/tasks/sparkfabrik-http-proxy.yml
+++ b/playbooks/roles/docker/tasks/sparkfabrik-http-proxy.yml
@@ -2,13 +2,23 @@
 - name: Install and configure SparkFabrik HTTP Proxy
   tags: [packages, dev, cloudnative, docker, spark-http-proxy]
   block:
-    - name: Install required packages
+    - name: Install required packages (Archlinux)
       community.general.pacman:
         name:
           - mkcert
           - nss
         state: present
         update_cache: yes
+      when: ansible_os_family == "Archlinux"
+
+    - name: Install required packages (Debian/Ubuntu)
+      ansible.builtin.apt:
+        name:
+          - mkcert
+          - libnss3-tools
+        state: present
+        update_cache: yes
+      when: ansible_os_family == "Debian"
 
     - name: Configure mkcert
       command: mkcert -install
@@ -21,36 +31,36 @@
 
     - name: Create ~/.local/spark/http-proxy directory to host configuration files
       ansible.builtin.file:
-        path: "{{ system.home }}/.local/spark/http-proxy"
+        path: "{{ system.home | default(current_home) }}/.local/spark/http-proxy"
         state: directory
         mode: "0755"
 
     - name: Change ownership of the ~/.local/spark directory
       ansible.builtin.file:
-        dest: "{{ system.home }}/.local/spark"
-        owner: "{{ system.username }}"
-        group: "{{ system.username }}"
+        dest: "{{ system.home | default(current_home) }}/.local/spark"
+        owner: "{{ system.username | default(current_user) }}"
+        group: "{{ system.username | default(current_user) }}"
 
     - name: Change ownership of the ~/.local/spark/http-proxy directory
       ansible.builtin.file:
-        dest: "{{ system.home }}/.local/spark/http-proxy"
-        owner: "{{ system.username }}"
-        group: "{{ system.username }}"
+        dest: "{{ system.home | default(current_home) }}/.local/spark/http-proxy"
+        owner: "{{ system.username | default(current_user) }}"
+        group: "{{ system.username | default(current_user) }}"
 
     - name: Download SparkFabrik HTTP Proxy compose file
       ansible.builtin.get_url:
         url: https://raw.githubusercontent.com/sparkfabrik/http-proxy/refs/heads/main/bin/compose.yml
-        dest: "{{ system.home }}/.local/spark/http-proxy/compose.yml"
+        dest: "{{ system.home | default(current_home) }}/.local/spark/http-proxy/compose.yml"
         mode: "0644"
 
     - name: Change ownership of the SparkFabrik HTTP Proxy script
       ansible.builtin.file:
         dest: /usr/local/bin/spark-http-proxy
-        owner: "{{ system.username }}"
-        group: "{{ system.username }}"
+        owner: "{{ system.username | default(current_user) }}"
+        group: "{{ system.username | default(current_user) }}"
 
     - name: Change ownership of the SparkFabrik HTTP Proxy compose file
       ansible.builtin.file:
-        dest: "{{ system.home }}/.local/spark/http-proxy/compose.yml"
-        owner: "{{ system.username }}"
-        group: "{{ system.username }}"
+        dest: "{{ system.home | default(current_home) }}/.local/spark/http-proxy/compose.yml"
+        owner: "{{ system.username | default(current_user) }}"
+        group: "{{ system.username | default(current_user) }}"

--- a/playbooks/roles/sparkdock/tasks/main.yml
+++ b/playbooks/roles/sparkdock/tasks/main.yml
@@ -59,13 +59,23 @@
   when: sparkfabrik | default(true)
   tags: [sparkfabrik, sparkdock, ajust]
   block:
-    - name: Install `ajust` packages
+    - name: Install `ajust` packages (Archlinux)
       become: yes
       community.general.pacman:
         name:
           - just
           - gum
         state: present
+      when: ansible_os_family == "Archlinux"
+
+    - name: Install `ajust` packages (Debian/Ubuntu)
+      become: yes
+      ansible.builtin.apt:
+        name:
+          - just
+          - gum
+        state: present
+      when: ansible_os_family == "Debian"
 
     - name: Install ajust wrapper script
       become: yes
@@ -101,9 +111,19 @@
     - name: Generate ajust zsh completion
       become: yes
       become_user: "{{ system.username | default(current_user) }}"
-      ansible.builtin.shell: |
-        just --completions zsh | sed -E 's/([\(_" ])just/\1ajust/g' > "{{ system.home | default(current_home) }}/.local/share/zsh/site-functions/_ajust"
-      changed_when: true
+      ansible.builtin.shell:
+        cmd: just --completions zsh | sed -E 's/([\(_" ])just/\1ajust/g'
+        executable: /bin/bash
+      register: ajust_zsh_completion
+      changed_when: false
+
+    - name: Write ajust zsh completion file
+      become: yes
+      become_user: "{{ system.username | default(current_user) }}"
+      ansible.builtin.copy:
+        content: "{{ ajust_zsh_completion.stdout }}"
+        dest: "{{ system.home | default(current_home) }}/.local/share/zsh/site-functions/_ajust"
+        mode: "0644"
 
     - name: Ensure ~/.local/spark/ajust/recipes directory exists
       become: yes
@@ -133,7 +153,25 @@
     - name: Run agent resources sync
       become: yes
       become_user: "{{ system.username | default(current_user) }}"
-      ansible.builtin.command: "{{ sparkdock.path | default(sparkdock_default_path) }}/bin/sparkdock-agents-sync"
+      ansible.builtin.shell: |
+        # Wrap gum to skip TTY-dependent subcommands (spin) in non-interactive Ansible context.
+        export _REAL_GUM=$(command -v gum)
+        gum() {
+          if [[ "$1" == "spin" ]]; then
+            shift
+            # Skip all arguments until the '--' separator.
+            while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+            # Skip the '--' separator itself.
+            [[ "${1:-}" == "--" ]] && shift
+            "$@"
+          else
+            "$_REAL_GUM" "$@"
+          fi
+        }
+        export -f gum
+        {{ sparkdock.path | default(sparkdock_default_path) }}/bin/sparkdock-agents-sync
+      args:
+        executable: /bin/bash
       register: agents_sync_output
       changed_when: "'added' in agents_sync_output.stdout or 'updated' in agents_sync_output.stdout"
 


### PR DESCRIPTION
 **Sparkdock role (sparkdock/tasks/main.yml):** 
The ajust package installation task is split into an Archlinux variant (using pacman) and a Debian/Ubuntu variant (using apt), installing just and gum on both. 

The zsh completion generation is also refactored, instead of a single shell pipeline that generates and writes the file in one shot, it now registers the output first and writes it with ansible.builtin.copy, which is cleaner and idempotent. 

The biggest change here is the sparkdock-agents-sync invocation: because gum spin requires a TTY and Ansible runs non-interactively, the task now wraps gum with a bash function that intercepts gum spin calls and runs the underlying command directly, skipping the spinner UI. This is a practical workaround for running sparkdock tooling in a headless Ansible context.

**docker/sparkfabrik-http-proxy (docker/tasks/sparkfabrik-http-proxy.yml):** 
The package installation for mkcert and its NSS dependency is similarly split by OS family (nss on Arch, libnss3-tools on Debian). 

All hardcoded references to system.home and system.username throughout the file gain | default(current_home) and | default(current_user) fallbacks, making the role usable when the system variable structure isn't fully defined — which is the case when running on a non-Arch system where the full config may not apply.