### PR TITLE
feat(packages): replace google-cloud-cli AUR packages with official tarball install

### DIFF
--- a/playbooks/roles/packages/tasks/development.yml
+++ b/playbooks/roles/packages/tasks/development.yml
@@ -30,8 +30,6 @@
           - act
           - cosign
           - crane
-          - google-cloud-cli
-          - google-cloud-cli-gke-gcloud-auth-plugin
           - grype-bin
           - kind
           - kubectx

--- a/playbooks/roles/packages/tasks/gcloud.yml
+++ b/playbooks/roles/packages/tasks/gcloud.yml
@@ -1,0 +1,57 @@
+---
+- name: Install Google Cloud SDK from official tarball
+  tags: [packages, dev, cloudnative, gcloud]
+  block:
+      - name: Remove google-cloud-cli AUR packages if installed
+        community.general.pacman:
+          name:
+            - google-cloud-cli
+            - google-cloud-cli-gke-gcloud-auth-plugin
+          state: absent
+        ignore_errors: true
+
+      - name: Check if Google Cloud SDK is already installed
+        ansible.builtin.stat:
+          path: /opt/google-cloud-sdk/bin/gcloud
+        register: gcloud_installed
+
+      - name: Download Google Cloud SDK tarball
+        ansible.builtin.get_url:
+          url: https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+          dest: /tmp/google-cloud-cli-linux-x86_64.tar.gz
+          mode: "0644"
+        when: not gcloud_installed.stat.exists
+
+      - name: Extract Google Cloud SDK to /opt
+        ansible.builtin.unarchive:
+          src: /tmp/google-cloud-cli-linux-x86_64.tar.gz
+          dest: /opt
+          remote_src: true
+        when: not gcloud_installed.stat.exists
+
+      - name: Run Google Cloud SDK install script
+        ansible.builtin.command:
+          cmd: /opt/google-cloud-sdk/install.sh --quiet --path-update false --command-completion false
+        when: not gcloud_installed.stat.exists
+        changed_when: true
+
+      - name: Install gke-gcloud-auth-plugin component
+        ansible.builtin.command:
+          cmd: /opt/google-cloud-sdk/bin/gcloud components install gke-gcloud-auth-plugin --quiet
+        register: gke_plugin_install
+        changed_when: "'All components are up to date' not in gke_plugin_install.stderr"
+
+      - name: Create /etc/profile.d/google-cloud-sdk.sh for PATH integration
+        ansible.builtin.copy:
+          dest: /etc/profile.d/google-cloud-sdk.sh
+          mode: "0644"
+          content: |
+            # Google Cloud SDK PATH integration
+            if [ -d /opt/google-cloud-sdk/bin ]; then
+              export PATH="/opt/google-cloud-sdk/bin:$PATH"
+            fi
+
+      - name: Clean up downloaded tarball
+        ansible.builtin.file:
+          path: /tmp/google-cloud-cli-linux-x86_64.tar.gz
+          state: absent

--- a/playbooks/roles/packages/tasks/gcloud.yml
+++ b/playbooks/roles/packages/tasks/gcloud.yml
@@ -57,16 +57,6 @@
           dest: /etc/bash_completion.d/google-cloud-sdk
           state: link
 
-      - name: Install zsh completion for gcloud commands
-        ansible.builtin.file:
-          src: /opt/google-cloud-sdk/completion.zsh.inc
-          dest: "/usr/share/zsh/site-functions/_{{ item }}"
-          state: link
-        loop:
-          - gcloud
-          - gsutil
-          - bq
-
       - name: Clean up downloaded tarball
         ansible.builtin.file:
           path: /tmp/google-cloud-cli-linux-x86_64.tar.gz

--- a/playbooks/roles/packages/tasks/gcloud.yml
+++ b/playbooks/roles/packages/tasks/gcloud.yml
@@ -51,6 +51,22 @@
               export PATH="/opt/google-cloud-sdk/bin:$PATH"
             fi
 
+      - name: Install bash completion for gcloud
+        ansible.builtin.file:
+          src: /opt/google-cloud-sdk/completion.bash.inc
+          dest: /etc/bash_completion.d/google-cloud-sdk
+          state: link
+
+      - name: Install zsh completion for gcloud commands
+        ansible.builtin.file:
+          src: /opt/google-cloud-sdk/completion.zsh.inc
+          dest: "/usr/share/zsh/site-functions/_{{ item }}"
+          state: link
+        loop:
+          - gcloud
+          - gsutil
+          - bq
+
       - name: Clean up downloaded tarball
         ansible.builtin.file:
           path: /tmp/google-cloud-cli-linux-x86_64.tar.gz

--- a/playbooks/roles/packages/tasks/main.yml
+++ b/playbooks/roles/packages/tasks/main.yml
@@ -23,5 +23,8 @@
 - name: Set up AI packages
   import_tasks: ai.yml
 
+- name: Set up Google Cloud SDK
+  import_tasks: gcloud.yml
+
 - name: Set up GitLab CLI (glab) and configuration
   import_tasks: glab.yml


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Removes `google-cloud-cli` and `google-cloud-cli-gke-gcloud-auth-plugin` from the AUR package list (unmaintained)
- Adds a new `gcloud.yml` task file that installs Google Cloud SDK from the official tarball to `/opt/google-cloud-sdk`
- Removes the AUR packages if they are currently installed (migration path)
- Installs `gke-gcloud-auth-plugin` via `gcloud components install` (now possible since it's not externally managed)
- Adds PATH integration via `/etc/profile.d/google-cloud-sdk.sh`
- Idempotent: skips download/install if `/opt/google-cloud-sdk/bin/gcloud` already exists

## Run with

```bash
TAGS=gcloud CONFIG=./config/default.yaml make local-install-tags
```

## Post-install

Updates are handled manually by the user via `gcloud components update`.

Closes #182