### PR TITLE
feat(sparkdock): use blockinfile for zshrc sourcing with SPARKDOCK_ENABLE_* vars

### DIFF
--- a/playbooks/roles/sparkdock/files/ajust/justfile
+++ b/playbooks/roles/sparkdock/files/ajust/justfile
@@ -63,6 +63,9 @@ sparkdock-fetch-updates:
 # Shared recipes from Sparkdock (only available once sparkdock is cloned)
 import? "~/.local/spark/sparkdock/sjust/recipes/04-shared.just"
 
+# Shell configuration recipes from Sparkdock
+import? "~/.local/spark/sparkdock/sjust/recipes/03-shell.just"
+
 # GitLab CLI (glab) recipes
 import? "~/.local/spark/ajust/recipes/01-gitlab.just"
 

--- a/playbooks/roles/sparkdock/tasks/main.yml
+++ b/playbooks/roles/sparkdock/tasks/main.yml
@@ -2,8 +2,6 @@
 - name: Import sparkdock features
   when: sparkdock.enabled | default(true)
   tags: [sparkfabrik, sparkdock, ajust]
-  vars:
-    include_string: '[[ ! -f "{{ sparkdock.path | default(sparkdock_default_path) }}/config/shell/sparkdock.zshrc" ]] || source "{{ sparkdock.path | default(sparkdock_default_path) }}/config/shell/sparkdock.zshrc"'
   become: yes
   become_user: "{{ system.username | default(current_user) }}"
   block:
@@ -27,11 +25,24 @@
         path: "{{ system.home | default(current_home) }}/.zshrc"
       register: zshrc_stat
 
-    - name: Ensure sparkdock zsh customization is included in the zshrc file
+    - name: Remove legacy single-line sparkdock source from zshrc
       ansible.builtin.lineinfile:
         path: "{{ system.home | default(current_home) }}/.zshrc"
-        regexp: 'sparkdock\.zshrc'
-        line: "{{ include_string }}"
+        regexp: '^\[\[.*sparkdock\.zshrc.*\]\].*source'
+        state: absent
+      when: zshrc_stat.stat.exists
+
+    - name: Ensure sparkdock zsh customization is included in the zshrc file
+      ansible.builtin.blockinfile:
+        path: "{{ system.home | default(current_home) }}/.zshrc"
+        marker: "# {mark} SPARKDOCK SHELL ENHANCEMENTS"
+        block: |
+          if [ -f "{{ sparkdock.path | default(sparkdock_default_path) }}/config/shell/sparkdock.zshrc" ]; then
+              export SPARKDOCK_ENABLE_STARSHIP=0
+              export SPARKDOCK_ENABLE_FZF=0
+              export SPARKDOCK_ENABLE_ATUIN=0
+              source "{{ sparkdock.path | default(sparkdock_default_path) }}/config/shell/sparkdock.zshrc"
+          fi
       when: zshrc_stat.stat.exists
 
     - name: Check if opencode config directory exists in home directory


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Replace `lineinfile` with `blockinfile` in sparkdock role to write the proper multi-line shell config block matching sparkdock's own `sjust shell-enable` output
- Add cleanup task to remove legacy single-line `[[ ! -f ... ]] || source ...` from existing zshrc files
- Set `SPARKDOCK_ENABLE_STARSHIP=0`, `SPARKDOCK_ENABLE_FZF=0`, `SPARKDOCK_ENABLE_ATUIN=0` to prevent sparkdock from re-initializing tools already configured by this provisioner
- Import `03-shell.just` in ajust justfile so `ajust shell-enable` / `ajust shell-info` / `ajust shell-disable` are available on Linux

## Why

The previous `lineinfile` approach injected a single line that sourced sparkdock without setting `SPARKDOCK_ENABLE_*` variables. This caused sparkdock to re-initialize starship, fzf, and atuin on top of the user's own configuration (duplicate prompt init, history conflicts).

## Dependencies

The `ajust shell-enable` recipe import depends on sparkfabrik/sparkdock#439 landing first (makes shell recipes use dynamic `SPARKDOCK_ROOT` instead of hardcoded `/opt/sparkdock`). The `blockinfile` Ansible change works independently.

Closes sparkfabrik/archlinux-ansible-provisioner#185