### PR TITLE
fix(sparkdock): correct dependency chain ordering and fix ansible_env deprecation #187

### DIFF
--- a/config/default.yaml.tpl
+++ b/config/default.yaml.tpl
@@ -54,7 +54,6 @@ desktop:
   browser:
     install_chrome_beta: false
 debug: false
-sparkdock:
-  enabled: true
+sparkdock: {}
 sparkfabrik: true
 qemu_for_buildx: true

--- a/config/schemas/configuration.schema.yaml
+++ b/config/schemas/configuration.schema.yaml
@@ -294,14 +294,6 @@ properties:
     description: Sparkdock configuration.
     additionalProperties: true
     properties:
-      enabled:
-        $id: "#/properties/sparkdock/properties/enabled"
-        type: boolean
-        default: false
-        title: Enable Sparkdock
-        description: Activate the Sparkdock feature.
-        examples:
-          - true
       path:
         $id: "#/properties/sparkdock/properties/path"
         type: string

--- a/playbooks/roles/sparkdock/tasks/main.yml
+++ b/playbooks/roles/sparkdock/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
+- name: Ensure sparkdock repository is cloned and up-to-date
+  tags: [always]
+  become: yes
+  become_user: "{{ system.username | default(current_user) }}"
+  block:
+    - name: Git checkout sparkdock
+      ansible.builtin.git:
+        repo: "https://github.com/sparkfabrik/sparkdock.git"
+        dest: "{{ sparkdock.path | default(sparkdock_default_path) }}"
+        version: master
+        update: yes
+        force: yes
+
 - name: Import sparkdock features
-  when: sparkdock.enabled | default(true)
   tags: [sparkfabrik, sparkdock, ajust]
   vars:
     include_string: '[[ ! -f "{{ sparkdock.path | default(sparkdock_default_path) }}/config/shell/sparkdock.zshrc" ]] || source "{{ sparkdock.path | default(sparkdock_default_path) }}/config/shell/sparkdock.zshrc"'
@@ -13,15 +25,6 @@
         state: directory
         mode: "0755"
 
-    - name: Git checkout sparkdock
-      ansible.builtin.git:
-        repo: "https://github.com/sparkfabrik/sparkdock.git"
-        dest: "{{ sparkdock.path | default(sparkdock_default_path) }}"
-        version: master
-        update: yes
-        force: yes
-        # version: <PUT THE DESIRED COMMIT SHA HERE FOR TESTING PURPOSES>
-
     - name: Check if .zshrc exists
       ansible.builtin.stat:
         path: "{{ system.home | default(current_home) }}/.zshrc"
@@ -33,27 +36,6 @@
         regexp: 'sparkdock\.zshrc'
         line: "{{ include_string }}"
       when: zshrc_stat.stat.exists
-
-    - name: Check if opencode config directory exists in home directory
-      ansible.builtin.stat:
-        path: "{{ system.home | default(current_home) }}/.config/opencode"
-      register: home_opencode_config_stat
-
-    - name: Ensure opencode config file is present in sparkdock cloned repository
-      ansible.builtin.stat:
-        path: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
-      register: sparkdock_opencode_config_stat
-
-    - name: Copy opencode config file from sparkdock if the opencode config directory exists
-      ansible.builtin.copy:
-        src: "{{ sparkdock.path | default(sparkdock_default_path) }}/config/macos/opencode.json"
-        dest: "{{ system.home | default(current_home) }}/.config/opencode/opencode.json"
-        mode: "0644"
-        owner: "{{ system.username | default(current_user) }}"
-        group: "{{ system.username | default(current_user) }}"
-      when:
-        - home_opencode_config_stat.stat.exists == true
-        - sparkdock_opencode_config_stat.stat.exists == true
 
 - name: Setup ajust (SparkJust for Linux)
   when: sparkfabrik | default(true)

--- a/playbooks/system.yml
+++ b/playbooks/system.yml
@@ -3,10 +3,11 @@
     - name: Auto-detect current user (like sparkdock uses ansible_facts['user_id'])
       tags: [always]
       ansible.builtin.set_fact:
-        current_user: "{{ ansible_env.SUDO_USER | default(ansible_facts['user_id']) }}"
-        current_home: "/home/{{ ansible_env.SUDO_USER | default(ansible_facts['user_id']) }}"
+        current_user: "{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['user_id']) }}"
+        current_home: "/home/{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['user_id']) }}"
   roles:
     - role: system
+    - role: sparkdock
     - role: packages
     - role: docker
     - role: nvidia
@@ -16,4 +17,3 @@
     - role: sparkfabrik
     - role: sway
     - role: i3
-    - role: sparkdock


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Move sparkdock role before packages in `system.yml` so downstream tasks (e.g., `packages/ai.yml`) can rely on the sparkdock repo being cloned
- Extract git clone into a `tags: [always]` block — ensures the repo is fresh regardless of which `--tags` filter is used
- Remove `sparkdock.enabled` config option (sparkdock always runs)
- Remove duplicate `opencode.json` copy logic from sparkdock role (packages/ai.yml owns config deployment with proper fallback)
- Fix `ansible_env.SUDO_USER` deprecation by replacing with `ansible_facts['env']['SUDO_USER']` (future-proofs for ansible-core 2.24)

Closes #187