### PR TITLE
docs(readme): update bootstrap command from install.linux to bootstrap.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The official guide is an invaluable resource for understanding the installation 
 
 Standalone installer for SparkFabrik shared dev tools on Arch Linux and Debian/Ubuntu. Works independently from the full system provisioner.
 
-### Quick Install
+### Quick Bootstrap
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/sparkfabrik/archlinux-ansible-provisioner/main/bin/install.linux)
+bash <(curl -fsSL https://raw.githubusercontent.com/sparkfabrik/archlinux-ansible-provisioner/main/bin/bootstrap.sh)
 ```
 
 ### Usage


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Update README.md quick bootstrap command to use `bootstrap.sh` instead of `install.linux`
- Rename "Quick Install" section to "Quick Bootstrap" for consistency

Refs: #189