### PR TITLE
feat(installer): add --help flag with colored output and OS detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,11 +62,11 @@ config/
   - name: Install and configure docker
     tags: [docker]
     block:
-        - name: Install docker
-          community.general.pacman:
-            name:
-              - docker
-              - docker-compose
+      - name: Install docker
+        community.general.pacman:
+          name:
+            - docker
+            - docker-compose
   ```
 
 ### Boolean Values
@@ -85,7 +85,7 @@ config/
 
 - Use **sentence case** (capitalize first word only): `"Install docker"`.
 - Be descriptive but concise. No trailing period.
-- Use backticks for technical terms: `` "Create the `aur_builder` user" ``.
+- Use backticks for technical terms: ``"Create the `aur_builder` user"``.
 
 ### Tags
 
@@ -163,6 +163,7 @@ config/
 ### Configuration Schema
 
 When adding new configurable features:
+
 1. Add the variable to `config/default.yaml.tpl` with a sensible default.
 2. Add the schema definition to `config/schemas/configuration.schema.yaml`.
 3. Use `| default()` in tasks for backward compatibility.
@@ -188,6 +189,10 @@ positive and add a comment explaining why.
 - Prefer early-return / guard-clause style over `else` branches.
 - Use `[[ ... ]]` over `[ ... ]` for conditionals.
 - Quote all variable expansions unless word splitting is intentionally needed.
+- Always use curly braces for variable references: `${VAR}`, not `$VAR`.
+  This applies everywhere: assignments, string interpolations, conditionals,
+  and command arguments. The only exceptions are positional parameters in
+  simple contexts (`$1`, `$2`, `$@`, `$?`).
 - Use `local` for function-scoped variables.
 - Source shared helpers from `bin/common/` (e.g., `logging.sh`) instead of
   duplicating color codes or utility functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `--help` / `-h` flag to `sf-toolbox` with colored output and OS detection display
 - Added `playbooks/roles/sf-toolbox/` role with per-tool task files (packages, gcloud, ai, glab, ajust, http-proxy)
 - Added `detect` section in toolbox package definitions for binary detection in the installer
 - Added clean arch/debian separation in toolbox package definitions with dotted-path support in the parser
 
 ### Changed
 
+- Standardized all shell variable references in `bin/install.linux` to use curly braces syntax (`${VAR}`)
 - Moved `config/toolbox-packages.yml` into `playbooks/roles/sf-toolbox/vars/main.yml` (auto-loaded by Ansible, no more `include_vars`)
 - Renamed `playbooks/toolbox.yml` to `playbooks/sf-toolbox.yml` for consistent naming with the `sf-toolbox` role and installer
 - Restructured toolbox package config from flat keys to nested `arch`/`debian`/`common` sections

--- a/bin/install.linux
+++ b/bin/install.linux
@@ -13,6 +13,36 @@
 #
 set -euo pipefail
 
+# ─── Help ───────────────────────────────────────────────────────────────────
+show_help() {
+  local os_icon
+  [[ "${OS_FAMILY}" == "Archlinux" ]] && os_icon="🐧" || os_icon="🟠"
+
+  printf "\n"
+  printf "  ${BOLD}${BLUE}sf-toolbox${NC} — SparkFabrik Linux Toolbox installer and updater\n"
+  printf "\n"
+  printf "  Installs/updates SparkFabrik shared dev tooling (sparkdock, AI tools,\n"
+  printf "  cloud-native CLIs, http-proxy) on Arch Linux and Debian/Ubuntu.\n"
+  printf "\n"
+  printf "  ${BOLD}Detected OS:${NC} ${GREEN}%s %s${NC} (%s)\n" "${os_icon}" "${OS_DISPLAY}" "${OS_FAMILY}"
+  printf "\n"
+  printf "  ${BOLD}Usage:${NC}\n"
+  printf "    sf-toolbox                                     # Install or update\n"
+  printf "    TAGS=sparkdock,ai sf-toolbox                   # Run specific tags only\n"
+  printf "    SKIP_TAGS=gcloud,http-proxy sf-toolbox         # Skip specific tags\n"
+  printf "    NONINTERACTIVE=1 sf-toolbox                    # Skip prompts (CI/scripts)\n"
+  printf "\n"
+  printf "  ${BOLD}Environment variables:${NC}\n"
+  printf "    TAGS           Comma-separated list of Ansible tags to run\n"
+  printf "    SKIP_TAGS      Comma-separated list of Ansible tags to skip\n"
+  printf "    CONFIG         Path to config YAML (default: config/default.yaml)\n"
+  printf "    NONINTERACTIVE Set to 1 to skip all interactive prompts\n"
+  printf "\n"
+  printf "  ${BOLD}Options:${NC}\n"
+  printf "    -h, --help     Show this help message and exit\n"
+  printf "\n"
+}
+
 # ─── Configuration ──────────────────────────────────────────────────────────
 INSTALL_DIR="/opt/archlinux-provisioner"
 REPO_URL="https://github.com/sparkfabrik/archlinux-ansible-provisioner.git"
@@ -45,30 +75,37 @@ detect_os() {
       exit 1
       ;;
   esac
-  OS_DISPLAY="${PRETTY_NAME:-$OS_FAMILY}"
+  OS_DISPLAY="${PRETTY_NAME:-${OS_FAMILY}}"
 }
 
+# Handle --help after detect_os so we can show the detected OS
+detect_os
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  show_help
+  exit 0
+fi
+
 resolve_repo_dir() {
-  if [[ -d "$INSTALL_DIR/.git" ]]; then
-    REPO_DIR="$INSTALL_DIR"
+  if [[ -d "${INSTALL_DIR}/.git" ]]; then
+    REPO_DIR="${INSTALL_DIR}"
   else
-    REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+    REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
   fi
 }
 
 show_status() {
-  local parser="$REPO_DIR/bin/common/parse-toolbox-packages.py"
-  local packages_file="$REPO_DIR/playbooks/roles/sf-toolbox/vars/main.yml"
+  local parser="${REPO_DIR}/bin/common/parse-toolbox-packages.py"
+  local packages_file="${REPO_DIR}/playbooks/roles/sf-toolbox/vars/main.yml"
 
-  [[ -f "$parser" && -f "$packages_file" ]] || return 0
+  [[ -f "${parser}" && -f "${packages_file}" ]] || return 0
 
   local installed=() missing=()
-  mapfile -t tools < <(python3 "$parser" "$packages_file" toolbox.detect)
+  mapfile -t tools < <(python3 "${parser}" "${packages_file}" toolbox.detect)
   for tool in "${tools[@]}"; do
-    if command -v "$tool" &>/dev/null; then
-      installed+=("$tool")
+    if command -v "${tool}" &>/dev/null; then
+      installed+=("${tool}")
     else
-      missing+=("$tool")
+      missing+=("${tool}")
     fi
   done
 
@@ -79,7 +116,7 @@ show_status() {
     missing+=("sparkdock")
   fi
 
-  log_info "sf-toolbox — $OS_DISPLAY"
+  log_info "sf-toolbox — ${OS_DISPLAY}"
 
   if [[ ${#missing[@]} -eq 0 ]]; then
     log_info "All tools present. Ensuring latest versions..."
@@ -87,22 +124,22 @@ show_status() {
   fi
 
   # First run or missing tools — show details
-  if [[ "$OS_FAMILY" == "Debian" ]]; then
+  if [[ "${OS_FAMILY}" == "Debian" ]]; then
     printf "\n  Tools to install:\n\n"
     local tool_list=""
     for tool in "${missing[@]}"; do
-      [[ -n "$tool_list" ]] && tool_list+=", "
-      tool_list+="$tool"
+      [[ -n "${tool_list}" ]] && tool_list+=", "
+      tool_list+="${tool}"
     done
     # Wrap at ~54 chars with 4-space indent
-    printf "    %s\n" "$(echo "$tool_list" | fold -s -w 54)"
+    printf "    %s\n" "$(echo "${tool_list}" | fold -s -w 54)"
   else
     printf "\n"
     for tool in "${missing[@]}"; do
-      printf "  + %-18s (will install)\n" "$tool"
+      printf "  + %-18s (will install)\n" "${tool}"
     done
     for tool in "${installed[@]}"; do
-      printf "  ✓ %-18s (installed)\n" "$tool"
+      printf "  ✓ %-18s (installed)\n" "${tool}"
     done
   fi
 
@@ -113,14 +150,14 @@ show_status() {
 is_sf_managed() {
   local tool="$1" path="$2"
   # Brew-managed (Debian)
-  [[ "$path" == /home/linuxbrew/.linuxbrew/bin/* ]] && return 0
+  [[ "${path}" == /home/linuxbrew/.linuxbrew/bin/* ]] && return 0
   # Pacman/npm-global managed (Arch) — both install to /usr/bin
-  [[ "$OS_FAMILY" == "Archlinux" && "$path" == /usr/bin/* ]] && return 0
+  [[ "${OS_FAMILY}" == "Archlinux" && "${path}" == /usr/bin/* ]] && return 0
   # sf-toolbox direct installs (non-brew, non-pacman)
-  case "$tool" in
-    gcloud) [[ "$path" == "/opt/google-cloud-sdk/bin/gcloud" ]] && return 0 ;;
-    ajust) [[ "$path" == "/usr/local/bin/ajust" ]] && return 0 ;;
-    spark-http-proxy) [[ "$path" == "/usr/local/bin/spark-http-proxy" ]] && return 0 ;;
+  case "${tool}" in
+    gcloud) [[ "${path}" == "/opt/google-cloud-sdk/bin/gcloud" ]] && return 0 ;;
+    ajust) [[ "${path}" == "/usr/local/bin/ajust" ]] && return 0 ;;
+    spark-http-proxy) [[ "${path}" == "/usr/local/bin/spark-http-proxy" ]] && return 0 ;;
   esac
   return 1
 }
@@ -130,32 +167,32 @@ get_provenance() {
   local pkg
 
   # Check npm (symlink into node_modules)
-  if [[ -L "$path" ]]; then
+  if [[ -L "${path}" ]]; then
     local target
-    target=$(readlink -f "$path" 2>/dev/null)
-    if [[ "$target" == *"node_modules"* ]]; then
+    target=$(readlink -f "${path}" 2>/dev/null)
+    if [[ "${target}" == *"node_modules"* ]]; then
       echo "npm"
       return
     fi
   fi
 
   # Check apt (Debian)
-  if [[ "$OS_FAMILY" == "Debian" ]]; then
-    if pkg=$(dpkg -S "$path" 2>/dev/null | head -1 | cut -d: -f1); then
-      echo "apt: $pkg"
+  if [[ "${OS_FAMILY}" == "Debian" ]]; then
+    if pkg=$(dpkg -S "${path}" 2>/dev/null | head -1 | cut -d: -f1); then
+      echo "apt: ${pkg}"
       return
     fi
   fi
 
   # Check pacman (Arch)
-  if [[ "$OS_FAMILY" == "Archlinux" ]]; then
-    if pkg=$(pacman -Qo "$path" 2>/dev/null | awk '{print $(NF-1)}'); then
-      [[ -n "$pkg" ]] && { echo "pacman: $pkg"; return; }
+  if [[ "${OS_FAMILY}" == "Archlinux" ]]; then
+    if pkg=$(pacman -Qo "${path}" 2>/dev/null | awk '{print $(NF-1)}'); then
+      [[ -n "${pkg}" ]] && { echo "pacman: ${pkg}"; return; }
     fi
   fi
 
   # Check snap
-  if [[ "$path" == /snap/bin/* ]]; then
+  if [[ "${path}" == /snap/bin/* ]]; then
     echo "snap"
     return
   fi
@@ -166,36 +203,36 @@ get_provenance() {
 
 get_removal_cmd() {
   local tool="$1" path="$2" provenance="$3"
-  case "$provenance" in
+  case "${provenance}" in
     apt:*)
       local pkg="${provenance#apt: }"
-      echo "sudo apt remove --purge $pkg"
+      echo "sudo apt remove --purge ${pkg}"
       ;;
     pacman:*)
       local pkg="${provenance#pacman: }"
-      echo "sudo pacman -Rns $pkg"
+      echo "sudo pacman -Rns ${pkg}"
       ;;
     snap)
-      echo "sudo snap remove $tool"
+      echo "sudo snap remove ${tool}"
       ;;
     npm)
       # Extract npm package name from symlink target (handles @scope/name)
       local target npm_pkg
-      target=$(readlink -f "$path" 2>/dev/null)
-      npm_pkg=$(echo "$target" | sed -n 's|.*node_modules/\(@[^/]*/[^/]*\)/.*|\1|p')
-      if [[ -z "$npm_pkg" ]]; then
-        npm_pkg=$(echo "$target" | sed -n 's|.*node_modules/\([^/]*\)/.*|\1|p')
+      target=$(readlink -f "${path}" 2>/dev/null)
+      npm_pkg=$(echo "${target}" | sed -n 's|.*node_modules/\(@[^/]*/[^/]*\)/.*|\1|p')
+      if [[ -z "${npm_pkg}" ]]; then
+        npm_pkg=$(echo "${target}" | sed -n 's|.*node_modules/\([^/]*\)/.*|\1|p')
       fi
-      npm_pkg="${npm_pkg:-$tool}"
+      npm_pkg="${npm_pkg:-${tool}}"
       # User-local install (under $HOME) doesn't need sudo
-      if [[ "$path" == "$HOME"/* || "$path" == /home/* ]]; then
-        echo "npm uninstall -g $npm_pkg"
+      if [[ "${path}" == "${HOME}"/* || "${path}" == /home/* ]]; then
+        echo "npm uninstall -g ${npm_pkg}"
       else
-        echo "sudo npm uninstall -g $npm_pkg"
+        echo "sudo npm uninstall -g ${npm_pkg}"
       fi
       ;;
     *)
-      echo "sudo rm $path"
+      echo "sudo rm ${path}"
       ;;
   esac
 }
@@ -204,32 +241,32 @@ check_conflicts() {
   # Skip in non-interactive mode (CI environments are controlled)
   [[ "${NONINTERACTIVE:-0}" == "1" ]] && return 0
 
-  local parser="$REPO_DIR/bin/common/parse-toolbox-packages.py"
-  local packages_file="$REPO_DIR/playbooks/roles/sf-toolbox/vars/main.yml"
+  local parser="${REPO_DIR}/bin/common/parse-toolbox-packages.py"
+  local packages_file="${REPO_DIR}/playbooks/roles/sf-toolbox/vars/main.yml"
 
-  [[ -f "$parser" && -f "$packages_file" ]] || return 0
+  [[ -f "${parser}" && -f "${packages_file}" ]] || return 0
 
   local -a conflict_tools=() conflict_paths=() conflict_provs=() conflict_cmds=()
-  mapfile -t tools < <(python3 "$parser" "$packages_file" toolbox.detect)
+  mapfile -t tools < <(python3 "${parser}" "${packages_file}" toolbox.detect)
 
   for tool in "${tools[@]}"; do
     local tool_path
-    tool_path=$(command -v "$tool" 2>/dev/null) || continue
+    tool_path=$(command -v "${tool}" 2>/dev/null) || continue
 
     # If it's already managed by sf-toolbox, no conflict
-    if is_sf_managed "$tool" "$tool_path"; then
+    if is_sf_managed "${tool}" "${tool_path}"; then
       continue
     fi
 
     local prov
-    prov=$(get_provenance "$tool_path")
+    prov=$(get_provenance "${tool_path}")
     local cmd
-    cmd=$(get_removal_cmd "$tool" "$tool_path" "$prov")
+    cmd=$(get_removal_cmd "${tool}" "${tool_path}" "${prov}")
 
-    conflict_tools+=("$tool")
-    conflict_paths+=("$tool_path")
-    conflict_provs+=("$prov")
-    conflict_cmds+=("$cmd")
+    conflict_tools+=("${tool}")
+    conflict_paths+=("${tool_path}")
+    conflict_provs+=("${prov}")
+    conflict_cmds+=("${cmd}")
   done
 
   [[ ${#conflict_tools[@]} -eq 0 ]] && return 0
@@ -256,10 +293,10 @@ check_conflicts() {
   for i in "${!conflict_cmds[@]}"; do
     if [[ "${conflict_provs[$i]}" == apt:* ]]; then
       local pkg="${conflict_provs[$i]#apt: }"
-      apt_pkgs+=("$pkg")
+      apt_pkgs+=("${pkg}")
     elif [[ "${conflict_provs[$i]}" == pacman:* ]]; then
       local pkg="${conflict_provs[$i]#pacman: }"
-      pacman_pkgs+=("$pkg")
+      pacman_pkgs+=("${pkg}")
     else
       other_cmds+=("${conflict_cmds[$i]}")
     fi
@@ -272,7 +309,7 @@ check_conflicts() {
     printf "    sudo pacman -Rns %s\n" "${pacman_pkgs[*]}"
   fi
   for cmd in "${other_cmds[@]}"; do
-    printf "    %s\n" "$cmd"
+    printf "    %s\n" "${cmd}"
   done
 
   printf "\n"
@@ -284,7 +321,7 @@ check_conflicts() {
 # ─── Bootstrap ──────────────────────────────────────────────────────────────
 confirm_homebrew() {
   # Only on Debian, only on first install (brew not yet present)
-  [[ "$OS_FAMILY" != "Debian" ]] && return 0
+  [[ "${OS_FAMILY}" != "Debian" ]] && return 0
   [[ -f /home/linuxbrew/.linuxbrew/bin/brew ]] && return 0
 
   printf "  ────────────────────────────────────────────────────────\n"
@@ -324,7 +361,7 @@ ensure_ansible() {
   command -v ansible-playbook &>/dev/null && return 0
 
   log_info "Installing Ansible..."
-  case "$OS_FAMILY" in
+  case "${OS_FAMILY}" in
     Archlinux) sudo pacman -S --noconfirm ansible ;;
     Debian) sudo apt-get update -qq && sudo apt-get install -y -qq ansible ;;
   esac
@@ -332,42 +369,42 @@ ensure_ansible() {
 
 clone_or_update() {
   # When running from a local dev checkout (not the installed copy), skip clone
-  if [[ "$REPO_DIR" != "$INSTALL_DIR" ]]; then
-    log_info "Running from local checkout: $REPO_DIR"
+  if [[ "${REPO_DIR}" != "${INSTALL_DIR}" ]]; then
+    log_info "Running from local checkout: ${REPO_DIR}"
     return 0
   fi
 
-  if [[ -d "$INSTALL_DIR/.git" ]]; then
-    log_info "Updating $INSTALL_DIR from $REPO_URL..."
-    git -C "$INSTALL_DIR" pull --ff-only
+  if [[ -d "${INSTALL_DIR}/.git" ]]; then
+    log_info "Updating ${INSTALL_DIR} from ${REPO_URL}..."
+    git -C "${INSTALL_DIR}" pull --ff-only
   else
-    log_info "Cloning $REPO_URL → $INSTALL_DIR (requires sudo)..."
-    sudo mkdir -p "$INSTALL_DIR"
-    sudo chown "$USER:$USER" "$INSTALL_DIR"
-    git clone "$REPO_URL" "$INSTALL_DIR"
-    REPO_DIR="$INSTALL_DIR"
+    log_info "Cloning ${REPO_URL} → ${INSTALL_DIR} (requires sudo)..."
+    sudo mkdir -p "${INSTALL_DIR}"
+    sudo chown "${USER}:${USER}" "${INSTALL_DIR}"
+    git clone "${REPO_URL}" "${INSTALL_DIR}"
+    REPO_DIR="${INSTALL_DIR}"
   fi
 }
 
 run_ansible() {
   log_info "Installing Ansible dependencies..."
-  if ! ansible-galaxy collection install -r "$REPO_DIR/requirements.yml" --force-with-deps >/dev/null 2>&1; then
+  if ! ansible-galaxy collection install -r "${REPO_DIR}/requirements.yml" --force-with-deps >/dev/null 2>&1; then
     log_error "Failed to install Ansible collections. Run manually:"
-    log_error "  ansible-galaxy collection install -r $REPO_DIR/requirements.yml --force-with-deps"
+    log_error "  ansible-galaxy collection install -r ${REPO_DIR}/requirements.yml --force-with-deps"
     exit 1
   fi
-  local cmd=(sudo ansible-playbook "$REPO_DIR/playbooks/sf-toolbox.yml" -i "localhost," -c local)
-  [[ -n "${TAGS:-}" ]] && cmd+=(--tags "$TAGS")
-  [[ -n "${SKIP_TAGS:-}" ]] && cmd+=(--skip-tags "$SKIP_TAGS")
+  local cmd=(sudo ansible-playbook "${REPO_DIR}/playbooks/sf-toolbox.yml" -i "localhost," -c local)
+  [[ -n "${TAGS:-}" ]] && cmd+=(--tags "${TAGS}")
+  [[ -n "${SKIP_TAGS:-}" ]] && cmd+=(--skip-tags "${SKIP_TAGS}")
   "${cmd[@]}"
 }
 
 create_symlink() {
   # Only create symlink when running from the installed copy
-  [[ "$REPO_DIR" != "$INSTALL_DIR" ]] && return 0
+  [[ "${REPO_DIR}" != "${INSTALL_DIR}" ]] && return 0
 
-  if [[ ! -L "$SYMLINK_PATH" ]] || [[ "$(readlink -f "$SYMLINK_PATH")" != "$INSTALL_DIR/bin/install.linux" ]]; then
-    sudo ln -sf "$INSTALL_DIR/bin/install.linux" "$SYMLINK_PATH"
+  if [[ ! -L "${SYMLINK_PATH}" ]] || [[ "$(readlink -f "${SYMLINK_PATH}")" != "${INSTALL_DIR}/bin/install.linux" ]]; then
+    sudo ln -sf "${INSTALL_DIR}/bin/install.linux" "${SYMLINK_PATH}"
   fi
 }
 
@@ -383,7 +420,6 @@ shell_enable() {
 
 # ─── Main ───────────────────────────────────────────────────────────────────
 main() {
-  detect_os
   resolve_repo_dir
   show_status
   check_conflicts


### PR DESCRIPTION
### **User description**
Also standardize all shell variable references to curly braces syntax and document the convention in AGENTS.md.

Assisted-by: opencode/github-copilot/claude-opus-4.6


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added `--help` / `-h` flag to `sf-toolbox` with colored output and OS detection

- Standardized all shell variable references to use `${VAR}` curly brace syntax

- Documented shell variable convention in `AGENTS.md`

- Updated `CHANGELOG.md` with new features and changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bin/install.linux"] -- "detect_os() called early" --> B["detect_os()"]
  B -- "OS detected" --> C["show_help()"]
  C -- "-h / --help flag" --> D["Colored help output\nwith OS info"]
  A -- "curly brace\nstandardization" --> E["${VAR} syntax\nthroughout script"]
  F["AGENTS.md"] -- "documents convention" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.linux</strong><dd><code>Add --help flag and standardize variable syntax in installer</code></dd></summary>
<hr>

bin/install.linux

<ul><li>Added <code>show_help()</code> function with colored output, OS detection display, <br>usage, and environment variable documentation<br> <li> Moved <code>detect_os()</code> call before argument parsing so <code>--help</code> can display <br>detected OS<br> <li> Added <code>-h</code> / <code>--help</code> argument handling that calls <code>show_help()</code> and exits<br> <li> Standardized all shell variable references from <code>$VAR</code> to <code>${VAR}</code> <br>throughout the script<br> <li> Removed duplicate <code>detect_os</code> call from <code>main()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/193/files#diff-877d32c0cf553e367aaf499a3e8982edb759c30fde98862b7039c47a2f128e58">+119/-83</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Document shell variable curly brace convention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Added documentation rule requiring curly braces for all variable <br>references (<code>${VAR}</code>)<br> <li> Noted exceptions for simple positional parameters (<code>$1</code>, <code>$2</code>, <code>$@</code>, <code>$?</code>)<br> <li> Fixed YAML indentation in example block<br> <li> Minor formatting fixes (backtick spacing, blank line addition)</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/193/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with new features and changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry for <code>--help</code> / <code>-h</code> flag addition to <code>sf-toolbox</code><br> <li> Added entry for shell variable curly brace standardization in <br><code>bin/install.linux</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/193/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

