### PR TITLE
chore(openspec): add spec for system-wide opencode config

### DIFF
--- a/openspec/changes/system-wide-opencode-config/.openspec.yaml
+++ b/openspec/changes/system-wide-opencode-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/system-wide-opencode-config/design.md
+++ b/openspec/changes/system-wide-opencode-config/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The `sf-toolbox` role's `ai.yml` currently deploys the base `opencode.json`
+into the user's home directory at `~/.config/opencode/opencode.json`. Because
+opencode merges system-wide (`/etc/opencode/opencode.json`) and user-local
+(`~/.config/opencode/opencode.json`) configuration, placing the shipped
+defaults under `/etc/opencode/` frees the user-local path for personal
+overrides that survive re-provisioning.
+
+All tasks in `ai.yml` run inside a single `block:` under the
+`Configure AI tools` play. The playbook is executed with `sudo`, so writing to
+`/etc/` requires no additional `become:` directive; writing user-owned paths
+still uses the existing owner/group variables.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Deploy the base opencode configuration to `/etc/opencode/opencode.json`
+  owned by `root:root`.
+- Keep `~/.config/opencode/` as a user-owned directory for personal
+  configuration overrides.
+- Inform the user (via `ansible.builtin.debug`) that they can create
+  `~/.config/opencode/opencode.json` for custom settings.
+
+**Non-Goals:**
+
+- Modifying the opencode configuration content itself.
+- Implementing any config-merge logic (opencode already handles this).
+- Managing additional files under `/etc/opencode/`.
+
+## Decisions
+
+### 1. Destination path: `/etc/opencode/opencode.json`
+
+OpenCode natively reads `/etc/opencode/opencode.json` as the system-wide
+config. Placing the shipped defaults there follows the tool's own convention
+and requires no extra flags or symlinks.
+
+**Alternative considered:** Symlinking `~/.config/opencode/opencode.json` to
+`/etc/opencode/opencode.json` — rejected because it would still occupy the
+user-local path and prevent personal overrides.
+
+### 2. Ownership `root:root` for `/etc/opencode/` and its contents
+
+System-wide configuration under `/etc/` should be owned by root to prevent
+unprivileged modification. This is standard practice on Linux systems.
+
+### 3. Debug message instead of a template or README
+
+A one-line `ansible.builtin.debug` message at provision time is the lightest
+way to inform users without creating additional files they might need to
+maintain. It keeps the role self-contained.
+
+## Risks / Trade-offs
+
+- **[Existing user-local file]** → Users who previously relied on the
+  provisioner writing `~/.config/opencode/opencode.json` will no longer get
+  that file. Mitigation: the debug message tells them where the system config
+  now lives and how to add personal overrides.

--- a/openspec/changes/system-wide-opencode-config/proposal.md
+++ b/openspec/changes/system-wide-opencode-config/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The opencode base configuration (`opencode.json`) is currently deployed to
+the user's home directory (`~/.config/opencode/opencode.json`). This prevents
+users from layering their own customizations on top of the shipped defaults,
+since the same path would be overwritten on every provisioning run. Moving the
+base config to `/etc/opencode/` establishes a clear system-wide vs. user-local
+split, letting users maintain personal overrides that are merged with the
+shipped configuration.
+
+## What Changes
+
+- Create `/etc/opencode/` directory owned by `root:root` with mode `0755`.
+- Copy the base `opencode.json` to `/etc/opencode/opencode.json` (owned by
+  `root:root`, mode `0644`) instead of `~/.config/opencode/opencode.json`.
+- Keep the `~/.config/opencode/` directory creation (user-owned) so users have
+  a ready location for their personal configuration.
+- Add a debug message informing the user they can place a custom
+  `~/.config/opencode/opencode.json` that will be merged with the system-wide
+  configuration.
+
+## Capabilities
+
+### New Capabilities
+
+- `system-opencode-config`: Ship the opencode base configuration to
+  `/etc/opencode/opencode.json` as a system-wide default, keeping user-local
+  `~/.config/opencode/` for personal customizations.
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- **Affected file**: `playbooks/roles/sf-toolbox/tasks/ai.yml` (lines 51-65).
+- No new dependencies or schema changes required — the config source path
+  remains the same, only the destination changes.
+- Existing user-local `~/.config/opencode/opencode.json` files will no longer
+  be overwritten by provisioning, which is the desired outcome.

--- a/openspec/changes/system-wide-opencode-config/specs/system-opencode-config/spec.md
+++ b/openspec/changes/system-wide-opencode-config/specs/system-opencode-config/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: System-wide opencode configuration directory
+The provisioner SHALL create the `/etc/opencode/` directory owned by `root:root`
+with mode `0755` before copying the configuration file.
+
+#### Scenario: Directory does not exist
+- **WHEN** the provisioner runs and `/etc/opencode/` does not exist
+- **THEN** the directory is created with owner `root`, group `root`, and mode `0755`
+
+#### Scenario: Directory already exists
+- **WHEN** the provisioner runs and `/etc/opencode/` already exists
+- **THEN** the directory ownership and permissions are enforced to `root:root` and `0755`
+
+### Requirement: Deploy base opencode configuration to system-wide path
+The provisioner SHALL copy the base `opencode.json` from the sparkdock config
+path to `/etc/opencode/opencode.json` with owner `root`, group `root`, and
+mode `0644`.
+
+#### Scenario: Configuration file is copied
+- **WHEN** the provisioner runs the copy task
+- **THEN** `/etc/opencode/opencode.json` exists with owner `root`, group `root`, and mode `0644`
+
+### Requirement: User-local opencode directory is preserved
+The provisioner SHALL continue to create `~/.config/opencode/` owned by the
+provisioned user so it is available for personal configuration overrides.
+
+#### Scenario: User directory is created
+- **WHEN** the provisioner runs
+- **THEN** `~/.config/opencode/` exists with the provisioned user as owner and group, mode `0755`
+
+### Requirement: Debug message about user customization
+The provisioner SHALL display a debug message informing the user that they can
+create `~/.config/opencode/opencode.json` as a personal customization file
+that will be merged with the system-wide configuration.
+
+#### Scenario: Debug message is displayed
+- **WHEN** the provisioner finishes configuring opencode
+- **THEN** a debug message is shown indicating that `~/.config/opencode/opencode.json` can be used for personal overrides merged with `/etc/opencode/opencode.json`

--- a/openspec/changes/system-wide-opencode-config/tasks.md
+++ b/openspec/changes/system-wide-opencode-config/tasks.md
@@ -1,0 +1,9 @@
+## 1. Update opencode config deployment in ai.yml
+
+- [ ] 1.1 Add task to create `/etc/opencode/` directory owned by `root:root` with mode `0755`
+- [ ] 1.2 Change the copy task destination from `~/.config/opencode/opencode.json` to `/etc/opencode/opencode.json` with owner `root:root` and mode `0644`
+- [ ] 1.3 Add `ansible.builtin.debug` task after the user-local directory creation informing users they can create `~/.config/opencode/opencode.json` for personal overrides
+
+## 2. Changelog
+
+- [ ] 2.1 Add entry to CHANGELOG.md under `## [Unreleased]`


### PR DESCRIPTION
Assisted-by: opencode/github-copilot/claude-opus-4.6