### PR TITLE
fix(gcloud): suppress usage reporting during installation and configure disable_usage_reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Disabled Google Cloud SDK usage reporting both at install time (`--usage-reporting false`) and persistently via `gcloud config set core/disable_usage_reporting true` to avoid sending telemetry to Google
 - Moved opencode base configuration from `~/.config/opencode/opencode.json` to `/etc/opencode/opencode.json` (user-owned, in a `root:root` directory) to support user-local overrides via `~/.config/opencode/opencode.json`
 - Added automatic cleanup of duplicate `~/.config/opencode/opencode.json` when identical to the shipped source, with a warning when the file contains non-custom content
 - Standardized all shell variable references in `bin/install.linux` to use curly braces syntax (`${VAR}`)

--- a/playbooks/roles/sf-toolbox/tasks/gcloud.yml
+++ b/playbooks/roles/sf-toolbox/tasks/gcloud.yml
@@ -23,9 +23,17 @@
 
     - name: Run Google Cloud SDK install script
       ansible.builtin.command:
-        cmd: /opt/google-cloud-sdk/install.sh --quiet --path-update false --command-completion false
+        cmd: /opt/google-cloud-sdk/install.sh --quiet --path-update false --command-completion false --usage-reporting false
       when: not gcloud_installed.stat.exists
       changed_when: true
+
+    - name: Disable gcloud usage reporting
+      become: true
+      become_user: "{{ system.username | default(current_user) }}"
+      ansible.builtin.command:
+        cmd: /opt/google-cloud-sdk/bin/gcloud config set core/disable_usage_reporting true
+      changed_when: false
+      when: gcloud_installed.stat.exists
 
     - name: Install gke-gcloud-auth-plugin component
       ansible.builtin.command:


### PR DESCRIPTION
### **User description**
Assisted-by: opencode/qwen3.6-35b-a3b-q5kxl


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `--usage-reporting false` flag to gcloud install script

- Add new task to explicitly disable gcloud usage reporting via config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gcloud install.sh"] -- "--usage-reporting false" --> B["Usage reporting suppressed at install"]
  C["gcloud config set"] -- "core/disable_usage_reporting true" --> D["Usage reporting disabled in config"]
  B --> E["gcloud installed without telemetry"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gcloud.yml</strong><dd><code>Disable gcloud usage reporting at install and config level</code></dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/gcloud.yml

<ul><li>Added <code>--usage-reporting false</code> flag to the gcloud SDK install script <br>command<br> <li> Added a new Ansible task to set <code>core/disable_usage_reporting true</code> via <br><code>gcloud config set</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/198/files#diff-e2ffb23cb5b425f1587a215e74c41224a5be67adf1314ff330297198a1ab5dd4">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

