### PR TITLE
refactor(sf-toolbox): move github-cli from packages role to sf-toolbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved `github-cli` (gh) installation from `packages` role to `sf-toolbox` role with Debian/Ubuntu support via Homebrew
 - Moved GitHub Copilot CLI installation from `packages/tasks/development.yml` to sf-toolbox role
 - Disabled Google Cloud SDK usage reporting both at install time (`--usage-reporting false`) and persistently via `gcloud config set core/disable_usage_reporting true` to avoid sending telemetry to Google
 - Moved opencode base configuration from `~/.config/opencode/opencode.json` to `/etc/opencode/opencode.json` (user-owned, in a `root:root` directory) to support user-local overrides via `~/.config/opencode/opencode.json`

--- a/playbooks/roles/packages/tasks/development.yml
+++ b/playbooks/roles/packages/tasks/development.yml
@@ -12,7 +12,6 @@
       community.general.pacman:
         name:
           - aws-cli-v2
-          - github-cli
           - helm
           - jless
           - jq

--- a/playbooks/roles/sf-toolbox/vars/main.yml
+++ b/playbooks/roles/sf-toolbox/vars/main.yml
@@ -11,6 +11,7 @@ toolbox:
     pacman:
       - just
       - gum
+      - github-cli
       - glab
       - mkcert
       - nss
@@ -34,6 +35,7 @@ toolbox:
     homebrew:
       - just
       - gum
+      - gh
       - glab
       - mkcert
       - anomalyco/tap/opencode
@@ -60,6 +62,7 @@ toolbox:
     - openspec
     - copilot
     - claude
+    - gh
     - glab
     - gcloud
     - mkcert


### PR DESCRIPTION
Assisted-by: opencode/github-copilot/claude-opus-4.6