### PR TITLE
fix(sf-toolbox): integrate rtk into conflict detection system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed rtk not detected by sf-toolbox conflict system; added `rtk` to `toolbox.detect` list and `is_sf_managed()`, removed redundant per-role `which -a` detection that didn't feed into the conflict resolver
 - Fixed `resolve_repo_dir` in `bin/install.linux` always preferring `/opt/archlinux-provisioner` over local checkout, preventing local development testing
 - Fixed `sf-toolbox` OS detection to treat `CachyOS` as `Archlinux`
 - Fixed `sf-toolbox` symlink breaking `SCRIPT_DIR` resolution by resolving symlinks with `readlink -f` before computing the directory

--- a/bin/install.linux
+++ b/bin/install.linux
@@ -159,6 +159,7 @@ is_sf_managed() {
   case "${tool}" in
     gcloud) [[ "${path}" == "/opt/google-cloud-sdk/bin/gcloud" ]] && return 0 ;;
     ajust) [[ "${path}" == "/usr/local/bin/ajust" ]] && return 0 ;;
+    rtk) [[ "${path}" == "/usr/local/bin/rtk" ]] && return 0 ;;
     spark-http-proxy) [[ "${path}" == "/usr/local/bin/spark-http-proxy" ]] && return 0 ;;
     claude) [[ "${path}" == "${HOME}/.local/bin/claude" ]] && return 0 ;;
   esac

--- a/playbooks/roles/sf-toolbox/tasks/rtk.yml
+++ b/playbooks/roles/sf-toolbox/tasks/rtk.yml
@@ -97,23 +97,6 @@
         - /tmp/rtk.tar.gz
         - /tmp/rtk-extract
 
-    - name: Detect other rtk installations outside /usr/local/bin
-      become: true
-      become_user: "{{ system.username | default(current_user) }}"
-      ansible.builtin.command: which -a rtk
-      register: rtk_all_paths
-      changed_when: false
-      failed_when: false
-
-    - name: Warn about unmanaged rtk installations
-      ansible.builtin.debug:
-        msg: >-
-          WARNING: Found rtk installed at {{ item }} which is not managed by
-          sf-toolbox. This may shadow /usr/local/bin/rtk depending on your
-          PATH order. Consider removing it so that the sf-toolbox-managed
-          version at /usr/local/bin/rtk is used consistently.
-      loop: "{{ rtk_all_paths.stdout_lines | default([]) | reject('equalto', '/usr/local/bin/rtk') | list }}"
-
 - name: Install rtk via Homebrew (Debian/Ubuntu)
   tags: [sf-toolbox, packages, rtk]
   when: ansible_facts['os_family'] == "Debian"
@@ -125,21 +108,6 @@
         name: rtk
         state: present
         path: /home/linuxbrew/.linuxbrew/bin
-
-    - name: Detect other rtk installations outside Homebrew
-      ansible.builtin.command: which -a rtk
-      register: rtk_all_paths
-      changed_when: false
-      failed_when: false
-
-    - name: Warn about unmanaged rtk installations
-      ansible.builtin.debug:
-        msg: >-
-          WARNING: Found rtk installed at {{ item }} which is not managed by
-          sf-toolbox. This may shadow the Homebrew-managed rtk depending on
-          your PATH order. Consider removing it so that the sf-toolbox-managed
-          version is used consistently.
-      loop: "{{ rtk_all_paths.stdout_lines | default([]) | reject('match', '/home/linuxbrew/') | list }}"
 
 - name: Configure rtk
   tags: [sf-toolbox, packages, rtk]

--- a/playbooks/roles/sf-toolbox/vars/main.yml
+++ b/playbooks/roles/sf-toolbox/vars/main.yml
@@ -69,6 +69,7 @@ toolbox:
     - just
     - gum
     - ajust
+    - rtk
     - spark-http-proxy
 
   # ─── Prerequisites ──────────────────────────────────────────────────────


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

rtk was missing from the sf-toolbox conflict detection system, so when a user had an older rtk at `~/.local/bin/rtk` (e.g. from a previous manual install), the installer wouldn't flag it as a conflict. After sf-toolbox installed the new version to `/usr/local/bin/rtk`, the old binary still took precedence in PATH.

## Changes

- Added `rtk` to `toolbox.detect` list in `vars/main.yml`
- Added `rtk` case to `is_sf_managed()` in `bin/install.linux` (recognizes `/usr/local/bin/rtk` as the managed path on Arch)
- Removed redundant per-role `which -a` detection + warning tasks from `rtk.yml` (both Arch and Debian blocks) since the conflict system in `bin/install.linux` handles this upstream

Closes #205