### PR TITLE
feat(sf-toolbox): switch claude-code to claude-code@latest cask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Switched Claude Code from `claude-code` (stable) to `claude-code@latest` cask on Debian/Ubuntu, which tracks latest releases instead of pinned stable versions; includes migration task to auto-uninstall old cask
 - Added `/usr/local/bin/sparkfabrik-claude-code-otel-headers` — Claude Code OTLP `otelHeadersHelper` script, sourced from sparkdock ([sparkfabrik/sparkdock#483](https://github.com/sparkfabrik/sparkdock/pull/483)).
 - Added automatic caveman configuration via sparkdock setup script (`sjust/scripts/caveman/setup.sh`) in `sf-toolbox` role, with fallback warning to run `ajust sf-caveman-install` manually
 - Added automatic rtk configuration via sparkdock setup script after installation, with fallback warning to run `ajust sf-rtk-setup` manually

--- a/playbooks/roles/sf-toolbox/tasks/packages.yml
+++ b/playbooks/roles/sf-toolbox/tasks/packages.yml
@@ -52,6 +52,17 @@
         path: /home/linuxbrew/.linuxbrew/bin
       when: ansible_facts['os_family'] == "Debian"
 
+    # Migration: uninstall claude-code (stable) before installing claude-code@latest
+    - name: Remove claude-code stable cask (replaced by claude-code@latest)
+      become: true
+      become_user: "{{ system.username | default(current_user) }}"
+      community.general.homebrew_cask:
+        name: claude-code
+        state: absent
+        path: /home/linuxbrew/.linuxbrew/bin
+      when: ansible_facts['os_family'] == "Debian"
+      ignore_errors: true
+
     - name: Install homebrew casks (Debian/Ubuntu)
       become: true
       become_user: "{{ system.username | default(current_user) }}"

--- a/playbooks/roles/sf-toolbox/vars/main.yml
+++ b/playbooks/roles/sf-toolbox/vars/main.yml
@@ -41,7 +41,7 @@ toolbox:
       - anomalyco/tap/opencode
       - openspec
     homebrew_casks:
-      - claude-code
+      - claude-code@latest
     # copilot-cli is installed via npm instead of brew cask because the
     # cask definition uses generate_completions_from_executable which is
     # broken on older Homebrew versions (e.g. Ubuntu 24.04).


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Switches from `claude-code` (stable) to `claude-code@latest` cask on Debian/Ubuntu, which tracks latest releases instead of pinned stable versions.

### Problem

The `claude-code` brew cask is pinned to stable releases only. Users get stuck on older versions (e.g., 2.1.145) even though newer ones exist (e.g., 2.1.156). The `claude-code@latest` cask tracks all releases.

### Changes

- `playbooks/roles/sf-toolbox/vars/main.yml`: `claude-code` → `claude-code@latest` in `homebrew_casks`
- `playbooks/roles/sf-toolbox/tasks/packages.yml`: migration task that uninstalls old `claude-code` stable cask before installing `claude-code@latest` (idempotent — no-op if already migrated)
- `CHANGELOG.md`: entry under `### Added`

### Scope

Debian/Ubuntu only. Arch Linux uses the official `curl` installer — not affected by this cask change.

Mirror of [sparkfabrik/sparkdock#491](https://github.com/sparkfabrik/sparkdock/pull/491).