### PR TITLE
fix(sf-toolbox): install base runtime deps before roles on Arch

### DIFF
--- a/playbooks/roles/sparkdock/tasks/main.yml
+++ b/playbooks/roles/sparkdock/tasks/main.yml
@@ -43,9 +43,11 @@
             # Skip the '--' separator itself.
             [[ "${1:-}" == "--" ]] && shift
             "$@"
-          else
+          elif [[ -n "$_REAL_GUM" ]]; then
             "$_REAL_GUM" "$@"
           fi
+          # If gum is not installed, non-spin calls become no-ops (cosmetic only)
+          # instead of executing an empty command (rc 127).
         }
         export -f gum
         {{ sparkdock.path | default(sparkdock_default_path) }}/bin/sparkdock-agents-sync

--- a/playbooks/sf-toolbox.yml
+++ b/playbooks/sf-toolbox.yml
@@ -23,6 +23,28 @@
         current_user: "{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['user_id']) }}"
         current_home: "/home/{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['user_id']) }}"
 
+    # The sparkdock and sf-toolbox roles assume a base dev environment is
+    # already present (on full workstation installs it is provided by the
+    # `packages` role). On a minimal Arch base these commands are missing,
+    # which made the playbook fail mid-run instead of up-front:
+    #   - gum            -> sparkdock "Run agent resources sync"
+    #   - zsh            -> sparkdock oh-my-zsh setup
+    #   - nodejs, npm    -> sf-toolbox "Install npm packages"
+    # (the oh-my-zsh shasum failure is fixed in sparkdock via a sha256sum
+    #  fallback; coreutils is always present, so no perl/shasum dependency.)
+    # These run before the roles so the toolbox playbook is self-contained.
+    - name: Ensure base runtime dependencies (Archlinux)
+      community.general.pacman:
+        name:
+          - gum
+          - nodejs-lts-iron
+          - npm
+          - zsh
+        state: present
+      become: true
+      when: ansible_facts['os_family'] == "Archlinux"
+      tags: [always]
+
   roles:
     - sparkdock
     - sf-toolbox

--- a/playbooks/sf-toolbox.yml
+++ b/playbooks/sf-toolbox.yml
@@ -37,7 +37,7 @@
       community.general.pacman:
         name:
           - gum
-          - nodejs-lts-iron
+          - nodejs-lts-krypton
           - npm
           - zsh
         state: present


### PR DESCRIPTION
The sf-toolbox playbook runs the sparkdock role before sf-toolbox, but the base dev environment (gum, node/npm, zsh) those roles rely on is only present on full workstation installs (via the packages role). On a minimal Arch base these are missing, so the playbook failed mid-run:
- gum         -> sparkdock 'Run agent resources sync'
- zsh         -> sparkdock oh-my-zsh setup
- nodejs, npm -> sf-toolbox 'Install npm packages'

Install them in pre_tasks so the toolbox playbook is self-contained, and guard the gum wrapper against a missing gum binary (no-op instead of rc 127).