### PR TITLE
feat(sf-toolbox): install LSP server binaries for Claude Code plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added language server binaries for Claude Code's official code-intelligence plugins to the `sf-toolbox` role so org-level `enabledPlugins` can wire them in without per-machine setup: `intelephense`, `typescript`, `typescript-language-server`, `pyright` via npm (covers `php-lsp`, `typescript-lsp`, `pyright-lsp` plugins) and `gopls` via pacman on Arch / Homebrew on Debian/Ubuntu (covers `gopls-lsp` plugin). LSP processes only spawn when matching file extensions are present in the workspace, so devs not working in a given language pay no runtime cost
 - Added automatic caveman configuration via sparkdock setup script (`sjust/scripts/caveman/setup.sh`) in `sf-toolbox` role, with fallback warning to run `ajust sf-caveman-install` manually
 - Added automatic rtk configuration via sparkdock setup script after installation, with fallback warning to run `ajust sf-rtk-setup` manually
 - Added rtk-ai (Rust Token Killer) installation to `sf-toolbox` role with automatic version management from GitHub releases

--- a/playbooks/roles/sf-toolbox/vars/main.yml
+++ b/playbooks/roles/sf-toolbox/vars/main.yml
@@ -16,9 +16,14 @@ toolbox:
       - mkcert
       - nss
       - opencode
+      - gopls
     npm:
       - "@fission-ai/openspec"
       - "@github/copilot"
+      - intelephense
+      - typescript
+      - typescript-language-server
+      - pyright
     remove:
       pacman:
         - google-cloud-cli
@@ -40,6 +45,7 @@ toolbox:
       - mkcert
       - anomalyco/tap/opencode
       - openspec
+      - gopls
     homebrew_casks:
       - claude-code
     # copilot-cli is installed via npm instead of brew cask because the
@@ -47,6 +53,10 @@ toolbox:
     # broken on older Homebrew versions (e.g. Ubuntu 24.04).
     npm:
       - "@github/copilot"
+      - intelephense
+      - typescript
+      - typescript-language-server
+      - pyright
 
   # ─── Common (both OSes) ─────────────────────────────────────────────────
   common:
@@ -71,6 +81,10 @@ toolbox:
     - ajust
     - rtk
     - spark-http-proxy
+    - intelephense
+    - typescript-language-server
+    - pyright-langserver
+    - gopls
 
   # ─── Prerequisites ──────────────────────────────────────────────────────
   # Must be available as commands before sf-toolbox runs.


### PR DESCRIPTION
## Summary

Port [sparkfabrik/sparkdock#495](https://github.com/sparkfabrik/sparkdock/issues/495) to the `sf-toolbox` role: install the language-server binaries required by Claude Code's official code-intelligence plugins so devs get PHP, TypeScript, Python, and Go diagnostics + navigation with no manual setup.

### `playbooks/roles/sf-toolbox/vars/main.yml`

- `arch.npm` + `debian.npm`: add `intelephense`, `typescript`, `typescript-language-server`, `pyright`
- `arch.pacman`: add `gopls` (Arch `extra` repo)
- `debian.homebrew`: add `gopls`
- `detect`: add `intelephense`, `typescript-language-server`, `pyright-langserver`, `gopls` for installer status display

Existing `packages.yml` tasks already loop these lists per-OS — no task changes needed.

### Plugin → binary mapping

| Plugin                                     | Binary spawned               | Install         |
| ------------------------------------------ | ---------------------------- | --------------- |
| `php-lsp@claude-plugins-official`        | `intelephense`             | npm             |
| `typescript-lsp@claude-plugins-official` | `typescript-language-server` | npm (+ `typescript` peer) |
| `pyright-lsp@claude-plugins-official`    | `pyright-langserver`       | npm (`pyright`) |
| `gopls-lsp@claude-plugins-official`      | `gopls`                    | pacman / brew   |

## Runtime cost

Claude Code only spawns a language server when the workspace contains matching file extensions. Devs not working in a given language pay zero runtime cost — only on-disk footprint.

## Test plan

- [ ] `TAGS=sf-toolbox CONFIG=./config/default.yaml make local-install-tags` installs the npm packages + `gopls` cleanly
- [ ] `which intelephense typescript-language-server pyright-langserver gopls` resolves on a freshly provisioned host

Closes sparkfabrik/sparkdock#495
