### PR TITLE
feat(sf-toolbox): add ripgrep to toolbox packages for Arch and Debian/Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `ripgrep` (`rg`) to `sf-toolbox` packages for both Arch Linux (pacman) and Debian/Ubuntu (Homebrew)
 - Added language server binaries for Claude Code's official code-intelligence plugins to the `sf-toolbox` role so org-level `enabledPlugins` can wire them in without per-machine setup: `intelephense`, `typescript`, `typescript-language-server`, `pyright` via npm (covers `php-lsp`, `typescript-lsp`, `pyright-lsp` plugins) and `gopls` via pacman on Arch / Homebrew on Debian/Ubuntu (covers `gopls-lsp` plugin). LSP processes only spawn when matching file extensions are present in the workspace, so devs not working in a given language pay no runtime cost
 - Switched Claude Code from `claude-code` (stable) to `claude-code@latest` cask on Debian/Ubuntu, which tracks latest releases instead of pinned stable versions; includes migration task to auto-uninstall old cask
 - Added `/usr/local/bin/sparkfabrik-claude-code-otel-headers` — Claude Code OTLP `otelHeadersHelper` script, sourced from sparkdock ([sparkfabrik/sparkdock#483](https://github.com/sparkfabrik/sparkdock/pull/483)).

--- a/playbooks/roles/sf-toolbox/vars/main.yml
+++ b/playbooks/roles/sf-toolbox/vars/main.yml
@@ -17,6 +17,7 @@ toolbox:
       - nss
       - opencode
       - gopls
+      - ripgrep
     npm:
       - "@fission-ai/openspec"
       - "@github/copilot"
@@ -46,6 +47,7 @@ toolbox:
       - anomalyco/tap/opencode
       - openspec
       - gopls
+      - ripgrep
     homebrew_casks:
       - claude-code@latest
     # copilot-cli is installed via npm instead of brew cask because the
@@ -79,6 +81,7 @@ toolbox:
     - just
     - gum
     - ajust
+    - rg
     - rtk
     - spark-http-proxy
     - intelephense


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Adds `ripgrep` (`rg`) to `toolbox.arch.pacman` for Arch Linux
- Adds `ripgrep` to `toolbox.debian.homebrew` for Debian/Ubuntu
- Adds `rg` to `toolbox.detect` for binary detection in the installer