### PR TITLE
fix(sf-toolbox): add user ~/.local/bin to play PATH

### DIFF
--- a/playbooks/sf-toolbox.yml
+++ b/playbooks/sf-toolbox.yml
@@ -14,7 +14,7 @@
     sparkfabrik: true
 
   environment:
-    PATH: "/home/linuxbrew/.linuxbrew/bin:{{ lookup('env', 'PATH') }}"
+    PATH: "{{ current_home | default('') }}/.local/bin:/home/linuxbrew/.linuxbrew/bin:{{ lookup('env', 'PATH') }}"
 
   pre_tasks:
     - name: Auto-detect current user


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #216

## Summary

The `sf-toolbox.yml` play runs under `sudo ansible-playbook`, so its `lookup('env', 'PATH')` resolves to root's PATH and never includes the invoking user's `~/.local/bin`. The official Claude installer in `ai.yml` puts `claude` there, so tasks could not see it.

## Change

Prepend `{{ current_home | default('') }}/.local/bin` to the play-level PATH. The `default('')` guard prevents the `pre_tasks` that define `current_home` from failing on an undefined variable (the environment is templated for every task, including the `set_fact` that defines it).

## Effect

- `ai.yml`'s "Check if Claude Code is already installed" (`claude --version`) now finds the binary instead of failing, so claude is no longer reinstalled via `curl | bash` on every run.
- The caveman setup invoked from the cloned sparkdock checkout can detect `claude` and wire its plugin and hooks during provisioning.

## Related

Companion sparkdock work is in sparkfabrik/sparkdock#517.