### PR TITLE
fix(sf-toolbox): upgrade npm packages on every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `sf-toolbox` npm packages (e.g. `@fission-ai/openspec`) never upgrading after first install by switching the Arch and Debian/Ubuntu npm install tasks from `state: present` to `state: latest`, matching the existing Homebrew behavior
 - Fixed rtk not detected by sf-toolbox conflict system; added `rtk` to `toolbox.detect` list and `is_sf_managed()`, removed redundant per-role `which -a` detection that didn't feed into the conflict resolver
 - Fixed `resolve_repo_dir` in `bin/install.linux` always preferring `/opt/archlinux-provisioner` over local checkout, preventing local development testing
 - Fixed `sf-toolbox` OS detection to treat `CachyOS` as `Archlinux`

--- a/playbooks/roles/sf-toolbox/tasks/packages.yml
+++ b/playbooks/roles/sf-toolbox/tasks/packages.yml
@@ -32,7 +32,7 @@
       community.general.npm:
         name: "{{ item }}"
         global: true
-        state: present
+        state: latest
       loop: "{{ toolbox.arch.npm }}"
       when: ansible_facts['os_family'] == "Archlinux"
 
@@ -78,6 +78,6 @@
       community.general.npm:
         name: "{{ item }}"
         global: true
-        state: present
+        state: latest
       loop: "{{ toolbox.debian.npm | default([]) }}"
       when: ansible_facts['os_family'] == "Debian"


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## What

Switch the `sf-toolbox` npm install tasks (Arch and Debian/Ubuntu) from `state: present` to `state: latest` in `playbooks/roles/sf-toolbox/tasks/packages.yml`.

## Why

`state: present` only installs an npm package when it is missing. It never upgrades an already-installed one. As a result tools like `@fission-ai/openspec` stayed pinned to whatever version was first installed (e.g. 1.3.1) and never moved to newer releases (1.4.1). `state: latest` keeps them current on every run, matching the existing Homebrew install behavior.

Affects all npm-managed tools: `@fission-ai/openspec`, `@github/copilot`, `intelephense`, `typescript`, `typescript-language-server`, `pyright`.

## Out of scope

- `pacman` left at `state: present`. Arch discourages partial upgrades outside a full `-Syu`.
- `apt` left at `state: present`. Those entries are system libraries (`libnss3-tools`, `nodejs`, `npm`).

Closes #218