### PR TITLE
fix(sf-toolbox): select python3 with PyYAML for package parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `sf-toolbox` failing with "PyYAML is not installed" when a Homebrew `python3` shadows the system interpreter on `PATH`; the installer now selects a `python3` that has PyYAML (preferring `/usr/bin/python3`) for the toolbox package parser
 - Fixed `sf-toolbox` npm packages (e.g. `@fission-ai/openspec`) never upgrading after first install by switching the Arch and Debian/Ubuntu npm install tasks from `state: present` to `state: latest`, matching the existing Homebrew behavior
 - Fixed rtk not detected by sf-toolbox conflict system; added `rtk` to `toolbox.detect` list and `is_sf_managed()`, removed redundant per-role `which -a` detection that didn't feed into the conflict resolver
 - Fixed `resolve_repo_dir` in `bin/install.linux` always preferring `/opt/archlinux-provisioner` over local checkout, preventing local development testing

--- a/bin/install.linux
+++ b/bin/install.linux
@@ -53,6 +53,24 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=common/logging.sh disable=SC1091
 source "${SCRIPT_DIR}/common/logging.sh"
 
+# ─── Python interpreter ───────────────────────────────────────────────────────
+# Pick a python3 that has PyYAML. Homebrew's python3 often shadows the system
+# interpreter on PATH (common on SparkFabrik dev machines), and that python
+# lacks PyYAML even though Ansible's system python has it. Prefer the system
+# interpreter, then fall back to whatever python3 is on PATH.
+yaml_python() {
+  local candidate
+  for candidate in /usr/bin/python3 python3; do
+    if command -v "${candidate}" &>/dev/null \
+      && "${candidate}" -c "import yaml" &>/dev/null; then
+      printf '%s' "${candidate}"
+      return 0
+    fi
+  done
+  log_error "No python3 with PyYAML found. Install it: /usr/bin/python3 -m pip install pyyaml"
+  return 1
+}
+
 # ─── Detection ──────────────────────────────────────────────────────────────
 detect_os() {
   local os_release_file="${OS_RELEASE_FILE:-/etc/os-release}"
@@ -101,8 +119,9 @@ show_status() {
 
   [[ -f "${parser}" && -f "${packages_file}" ]] || return 0
 
-  local installed=() missing=()
-  mapfile -t tools < <(python3 "${parser}" "${packages_file}" toolbox.detect)
+  local installed=() missing=() py
+  py="$(yaml_python)" || return 0
+  mapfile -t tools < <("${py}" "${parser}" "${packages_file}" toolbox.detect)
   for tool in "${tools[@]}"; do
     if command -v "${tool}" &>/dev/null; then
       installed+=("${tool}")
@@ -251,7 +270,9 @@ check_conflicts() {
   [[ -f "${parser}" && -f "${packages_file}" ]] || return 0
 
   local -a conflict_tools=() conflict_paths=() conflict_provs=() conflict_cmds=()
-  mapfile -t tools < <(python3 "${parser}" "${packages_file}" toolbox.detect)
+  local py
+  py="$(yaml_python)" || return 0
+  mapfile -t tools < <("${py}" "${parser}" "${packages_file}" toolbox.detect)
 
   for tool in "${tools[@]}"; do
     local tool_path

--- a/bin/install.linux
+++ b/bin/install.linux
@@ -67,7 +67,7 @@ yaml_python() {
       return 0
     fi
   done
-  log_error "No python3 with PyYAML found. Install it: /usr/bin/python3 -m pip install pyyaml"
+  log_error "No python3 with PyYAML found. Install your distro's PyYAML package (Arch: python-yaml, Debian/Ubuntu: python3-yaml)." >&2
   return 1
 }
 


### PR DESCRIPTION
The installer invoked the toolbox package parser with bare `python3`, which on machines where Homebrew's python3 shadows the system interpreter on PATH lacks PyYAML and failed with "PyYAML is not installed". Select a python3 that has PyYAML, preferring /usr/bin/python3 (where the pacman/apt ansible package installs it), and skip the parser-based status and conflict checks gracefully when none is found.

Assisted-by: claude-code/claude-opus-4-8