### PR TITLE
chore(packages): replace obsolete python yq with mikefarah go-yq v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the obsolete Python `yq` package (pacman) with `go-yq`, the mikefarah Go yq v4 (`extra` repo); the old `yq` is now removed first since the two packages conflict
 - Homebrew formulae, casks, and rtk now install with `state: latest` so packages upgrade on every run
 - Split rtk installation by OS: GitHub releases on Archlinux, Homebrew on Debian/Ubuntu
 - Moved `github-cli` (gh) installation from `packages` role to `sf-toolbox` role with Debian/Ubuntu support via Homebrew

--- a/playbooks/roles/packages/tasks/development.yml
+++ b/playbooks/roles/packages/tasks/development.yml
@@ -6,12 +6,14 @@
       community.general.pacman:
         name:
           - neofetch
+          - yq
         state: absent
 
     - name: Install cloud native packages
       community.general.pacman:
         name:
           - aws-cli-v2
+          - go-yq
           - helm
           - jless
           - jq
@@ -20,7 +22,6 @@
           - kustomize
           - terraform
           - yamllint
-          - yq
 
     - name: Install cloud native packages from aur
       kewlfft.aur.aur:


### PR DESCRIPTION
## Summary

Replaces the obsolete Python `yq` package (kislyuk, installed via pacman) with `go-yq` — the mikefarah Go yq v4 (`extra` repo, currently v4.53.3).

The two packages conflict (both ship `/usr/bin/yq`), so the old `yq` is added to the absent-packages list and removed before `go-yq` is installed.

## Changes

- `playbooks/roles/packages/tasks/development.yml`: add `yq` to the absent list, add `go-yq` to the pacman install list, drop `yq`.
- `CHANGELOG.md`: entry under `### Changed`.

## Test

```
TAGS=cloudnative CONFIG=./config/default.yaml make local-install-tags
yq --version   # yq (https://github.com/mikefarah/yq/) version v4.x
```