### PR TITLE
feat(sf-toolbox): configure *.loc dns on all OSes via spark-http-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Configured `*.loc` local DNS resolution on all OSes (including Debian/Ubuntu) by invoking `spark-http-proxy configure-dns` during `sf-toolbox` provisioning
 - Added `ripgrep` (`rg`) to `sf-toolbox` packages for both Arch Linux (pacman) and Debian/Ubuntu (Homebrew)
 - Added language server binaries for Claude Code's official code-intelligence plugins to the `sf-toolbox` role so org-level `enabledPlugins` can wire them in without per-machine setup: `intelephense`, `typescript`, `typescript-language-server`, `pyright` via npm (covers `php-lsp`, `typescript-lsp`, `pyright-lsp` plugins) and `gopls` via pacman on Arch / Homebrew on Debian/Ubuntu (covers `gopls-lsp` plugin). LSP processes only spawn when matching file extensions are present in the workspace, so devs not working in a given language pay no runtime cost
 - Switched Claude Code from `claude-code` (stable) to `claude-code@latest` cask on Debian/Ubuntu, which tracks latest releases instead of pinned stable versions; includes migration task to auto-uninstall old cask
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Delegated `*.loc` systemd-resolved configuration to the `spark-http-proxy` CLI and removed the bespoke `docker` role drop-in (`docker-dev-dns.conf`, `172.17.0.1:19322`); the CLI now writes `http-proxy.conf` (`127.0.0.1:19322`). Legacy `~docker`/dnsdock routing is no longer configured
 - Replaced the obsolete Python `yq` package (pacman) with `go-yq`, the mikefarah Go yq v4 (`extra` repo); the old `yq` is now removed first since the two packages conflict
 - Homebrew formulae, casks, and rtk now install with `state: latest` so packages upgrade on every run
 - Split rtk installation by OS: GitHub releases on Archlinux, Homebrew on Debian/Ubuntu

--- a/playbooks/roles/docker/tasks/main.yml
+++ b/playbooks/roles/docker/tasks/main.yml
@@ -18,19 +18,6 @@
     - name: Enable docker service
       shell: systemctl enable docker
 
-    - name: Create /etc/systemd/resolved.conf.d if not exists
-      file:
-        path: /etc/systemd/resolved.conf.d
-        state: directory
-
-    - name: Configure systemd-resolved to play well with dnsdock
-      copy:
-        dest: "/etc/systemd/resolved.conf.d/docker-dev-dns.conf"
-        content: |
-          [Resolve]
-          DNS=172.17.0.1:19322
-          Domains=~loc ~docker
-
     - name: Copy dnsdock start script
       copy:
         src: "spark-run-dnsdock"
@@ -46,12 +33,6 @@
         force: yes
         mode: u+rwx,g-wx,o-rwx
         owner: "{{ system.username }}"
-
-    - name: Restart systemd-resolved
-      ansible.builtin.systemd:
-        state: restarted
-        daemon_reload: yes
-        name: systemd-resolved
 
     - name: Install docker-credential-gcr to authenticate in Google Container Registry
       kewlfft.aur.aur:

--- a/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
+++ b/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
@@ -39,3 +39,20 @@
         dest: /usr/local/bin/spark-http-proxy
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
+
+    - name: Remove legacy docker-dev-dns.conf drop-in superseded by spark-http-proxy
+      ansible.builtin.file:
+        path: /etc/systemd/resolved.conf.d/docker-dev-dns.conf
+        state: absent
+      register: legacy_dns_dropin
+
+    - name: Configure system DNS for proxy domains via spark-http-proxy
+      ansible.builtin.command: spark-http-proxy configure-dns
+      register: configure_dns
+      changed_when: "'succeeded' in configure_dns.stdout"
+
+    - name: Restart systemd-resolved when the legacy drop-in was removed
+      ansible.builtin.systemd:
+        name: systemd-resolved
+        state: restarted
+      when: legacy_dns_dropin.changed


### PR DESCRIPTION
### **User description**
## What

Delegates host-side `*.loc` DNS wiring to the `spark-http-proxy` CLI so it works on **every OS**, not just the Arch full-system path.

## Why

`spark-http-proxy` is installed by the `sf-toolbox` role on both Arch and Debian/Ubuntu, and its bundled `dns` service answers `*.loc` on 19322. But the systemd-resolved drop-in that routed `*.loc` there lived only in the `docker` role (`system.yml`, Arch-only). A Debian/Ubuntu toolbox install therefore got the binary + mkcert CA but **no `*.loc` resolution**.

## How

- `roles/sf-toolbox/tasks/http-proxy.yml`: invoke `spark-http-proxy configure-dns` during provisioning. The CLI already owns this logic (writes `/etc/systemd/resolved.conf.d/http-proxy.conf`, `DNS=127.0.0.1:19322`, `Domains=~loc`, restarts resolved, no-ops without `systemctl`). Also removes the stale `docker-dev-dns.conf` and restarts resolved when it was present.
- `roles/docker/tasks/main.yml`: removes the bespoke systemd-resolved drop-in tasks (now redundant).

## Notes

- Prerequisite: docker present (bridge / dns container) — spark-http-proxy needs it anyway.
- No auto-start change: resolution is active once `spark-http-proxy start` runs (DNS already auto-configured on `start` too).
- **Behavior change:** legacy `~docker`/dnsdock routing is no longer configured (spark-http-proxy serves `loc` only).

## Verification

Debian/Ubuntu:
\`\`\`
sudo ansible-playbook playbooks/sf-toolbox.yml -i localhost, -c local --tags spark-http-proxy
cat /etc/systemd/resolved.conf.d/http-proxy.conf
resolvectl status
spark-http-proxy start && resolvectl query whoami.loc   # -> 127.0.0.1
\`\`\`

Arch (regression — single drop-in):
\`\`\`
sudo ansible-playbook playbooks/system.yml -i localhost, -c local --tags spark-http-proxy,docker --extra-vars "@./config/default.yaml"
ls /etc/systemd/resolved.conf.d/   # only http-proxy.conf, no docker-dev-dns.conf
\`\`\`

Closes #224


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Delegates `*.loc` DNS wiring to `spark-http-proxy configure-dns` CLI for all OSes

- Removes bespoke `docker` role systemd-resolved drop-in (`docker-dev-dns.conf`)

- Adds legacy drop-in cleanup and resolved restart in `sf-toolbox` provisioning

- Updates CHANGELOG with DNS configuration changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sf-toolbox provisioning"] -- "runs" --> B["spark-http-proxy configure-dns"]
  B -- "writes" --> C["/etc/systemd/resolved.conf.d/http-proxy.conf\n(127.0.0.1:19322)"]
  A -- "removes legacy" --> D["docker-dev-dns.conf\n(172.17.0.1:19322)"]
  D -- "triggers" --> E["systemd-resolved restart"]
  F["docker role"] -- "no longer manages" --> G["systemd-resolved drop-in"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document DNS configuration delegation in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry under "Added" for <code>*.loc</code> DNS resolution on all OSes via <br><code>spark-http-proxy configure-dns</code><br> <li> Added entry under "Changed" documenting delegation to <code>spark-http-proxy</code> <br>CLI and removal of <code>docker</code> role drop-in</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/225/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.yml</strong><dd><code>Remove bespoke systemd-resolved drop-in from docker role</code>&nbsp; </dd></summary>
<hr>

playbooks/roles/docker/tasks/main.yml

<ul><li>Removed task creating <code>/etc/systemd/resolved.conf.d</code> directory<br> <li> Removed task writing <code>docker-dev-dns.conf</code> with <code>172.17.0.1:19322</code> and <br><code>~loc ~docker</code> domains<br> <li> Removed <code>systemd-resolved</code> restart task (now handled by <code>sf-toolbox</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/225/files#diff-e449a0ab6862eb13fda66844472a7305b55733be859c8487328e3dd641351e7b">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>http-proxy.yml</strong><dd><code>Add DNS configuration via spark-http-proxy in sf-toolbox</code>&nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/http-proxy.yml

<ul><li>Added task to remove legacy <code>docker-dev-dns.conf</code> drop-in file<br> <li> Added task invoking <code>spark-http-proxy configure-dns</code> to configure DNS <br>for <code>*.loc</code><br> <li> Added conditional <code>systemd-resolved</code> restart when legacy drop-in was <br>removed</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/225/files#diff-27fa07238a0071150ba06d1e6d503e07d6fe92dd6cd50bbdae913dabb5f2f404">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

