### PR TITLE
fix(sf-toolbox): pass installed compose path to spark-http-proxy configure-dns

### DIFF
--- a/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
+++ b/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
@@ -33,6 +33,7 @@
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
+      register: proxy_compose
 
     - name: Set ownership of spark-http-proxy script
       ansible.builtin.file:
@@ -48,6 +49,8 @@
 
     - name: Configure system DNS for proxy domains via spark-http-proxy
       ansible.builtin.command: spark-http-proxy configure-dns
+      environment:
+        COMPOSE_FILE: "{{ proxy_compose.dest }}"
       register: configure_dns
       changed_when: "'succeeded' in configure_dns.stdout"
 


### PR DESCRIPTION
### **User description**
## Problem

The `Configure system DNS ... via spark-http-proxy` task (added in #225) fails during provisioning:

```
❌ Docker Compose file not found at /usr/local/bin/compose.yml
```

The task runs as root, so `HOME=/root`. The `spark-http-proxy` CLI derives its compose location from `${HOME}/.local/spark/http-proxy/compose.yml`; under root that path doesn't exist, so it falls back to `${SCRIPT_DIR}/compose.yml` (`/usr/local/bin/compose.yml`) and fails the compose guard before `configure-dns` does anything.

## Fix

Set `COMPOSE_FILE` for the task to the path the compose file was actually installed to — the registered `dest` of the download step (`proxy_compose.dest`), not a hardwired literal. The CLI honors `COMPOSE_FILE` over its `HOME`-based discovery.

Reproduced and verified locally: `HOME=/root spark-http-proxy show-config` prints the error; adding `COMPOSE_FILE=<dest>` clears it.

Refs #224


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes `configure-dns` failure when running as root during provisioning

- Registers `proxy_compose` result to capture the installed compose file path

- Sets `COMPOSE_FILE` environment variable so CLI finds the correct compose file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Download compose.yml"] -- "register" --> B["proxy_compose.dest"]
  B -- "set COMPOSE_FILE" --> C["spark-http-proxy configure-dns"]
  C -- "writes" --> D["/etc/systemd/resolved.conf.d/http-proxy.conf"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http-proxy.yml</strong><dd><code>Pass installed compose path to configure-dns via environment variable</code></dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/http-proxy.yml

<ul><li>Registers the result of the compose file download step as <br><code>proxy_compose</code><br> <li> Passes <code>COMPOSE_FILE: "{{ proxy_compose.dest }}"</code> as environment <br>variable to the <code>configure-dns</code> task<br> <li> Ensures the CLI resolves the correct compose file path when running as <br>root</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/226/files#diff-27fa07238a0071150ba06d1e6d503e07d6fe92dd6cd50bbdae913dabb5f2f404">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

