### PR TITLE
fix(sf-toolbox): force-upgrade spark-http-proxy on every run

### DIFF
--- a/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
+++ b/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
@@ -11,6 +11,7 @@
         url: https://raw.githubusercontent.com/sparkfabrik/http-proxy/refs/heads/main/bin/spark-http-proxy
         dest: /usr/local/bin/spark-http-proxy
         mode: "0755"
+        force: true
 
     - name: Create ~/.local/spark/http-proxy directory
       ansible.builtin.file:
@@ -33,6 +34,7 @@
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
+        force: true
       register: proxy_compose
 
     - name: Set ownership of spark-http-proxy script


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #227

## Change

Add `force: true` to the two `get_url` tasks in `playbooks/roles/sf-toolbox/tasks/http-proxy.yml` (the `spark-http-proxy` CLI script and its `compose.yml`).

## Why

Without `force`, `get_url` defaults to `force: no`: an existing destination is only refreshed through a conditional (If-Modified-Since) fetch, which depends on the upstream `Last-Modified` header and caching. That usually picks up changes but does not *guarantee* a re-provision upgrades the proxy. The macOS provisioner (sparkdock) upgrades deterministically (`git` with `force: yes, update: yes`); this makes the Linux path equally deterministic — every run pulls the current `main`.

This mirrors the existing pattern in `fix(sf-toolbox): upgrade npm packages on every run` (#218 / #219).

## Notes

- Both files track `main` HEAD (unchanged); this only changes *when* they are refreshed (always vs conditionally).
- YAML validated.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `force: true` to both `get_url` tasks in `http-proxy.yml`

- Ensures spark-http-proxy script is always re-downloaded on provisioning

- Ensures compose.yml is always re-downloaded on provisioning

- Makes Linux provisioning deterministic, matching macOS behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Provisioning Run"] -- "get_url force: true" --> B["spark-http-proxy script"]
  A -- "get_url force: true" --> C["compose.yml"]
  B -- "always pulls" --> D["main HEAD"]
  C -- "always pulls" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http-proxy.yml</strong><dd><code>Force re-download of http-proxy files on every run</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/http-proxy.yml

<ul><li>Added <code>force: true</code> to the <code>get_url</code> task downloading the <code>spark-http-proxy</code> <br>CLI script<br> <li> Added <code>force: true</code> to the <code>get_url</code> task downloading the <code>compose.yml</code> file<br> <li> Ensures both files are always refreshed on every provisioning run, <br>regardless of caching or <code>Last-Modified</code> headers</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/228/files#diff-27fa07238a0071150ba06d1e6d503e07d6fe92dd6cd50bbdae913dabb5f2f404">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

