### PR TITLE
feat(sf-toolbox): install spark-http-proxy via git clone + add ajust install/update recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `http-proxy-install-update` ajust recipe (group `http-proxy`) for parity with macOS sjust; installs/updates `spark-http-proxy` via the `spark-http-proxy` provisioner tag
 - Configured `*.loc` local DNS resolution on all OSes (including Debian/Ubuntu) by invoking `spark-http-proxy configure-dns` during `sf-toolbox` provisioning
 - Added `ripgrep` (`rg`) to `sf-toolbox` packages for both Arch Linux (pacman) and Debian/Ubuntu (Homebrew)
 - Added language server binaries for Claude Code's official code-intelligence plugins to the `sf-toolbox` role so org-level `enabledPlugins` can wire them in without per-machine setup: `intelephense`, `typescript`, `typescript-language-server`, `pyright` via npm (covers `php-lsp`, `typescript-lsp`, `pyright-lsp` plugins) and `gopls` via pacman on Arch / Homebrew on Debian/Ubuntu (covers `gopls-lsp` plugin). LSP processes only spawn when matching file extensions are present in the workspace, so devs not working in a given language pay no runtime cost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Install `spark-http-proxy` on Linux via a git clone + symlink (under `~/.local/spark/http-proxy/src`) instead of a standalone downloaded script, mirroring the macOS sparkdock mechanism. This makes `spark-http-proxy self-update` work, keeps the compose file in sync with the CLI, and deterministically updates to the latest `main` on every provision. Migrates existing installs by replacing the standalone CLI file with a symlink and removing the now-stale standalone `compose.yml` that would otherwise shadow the clone
 - Added `http-proxy-install-update` ajust recipe (group `http-proxy`) for parity with macOS sjust; installs/updates `spark-http-proxy` via the `spark-http-proxy` provisioner tag
 - Configured `*.loc` local DNS resolution on all OSes (including Debian/Ubuntu) by invoking `spark-http-proxy configure-dns` during `sf-toolbox` provisioning
 - Added `ripgrep` (`rg`) to `sf-toolbox` packages for both Arch Linux (pacman) and Debian/Ubuntu (Homebrew)

--- a/playbooks/roles/sf-toolbox/files/ajust/justfile
+++ b/playbooks/roles/sf-toolbox/files/ajust/justfile
@@ -87,6 +87,12 @@ provision-tags tags:
       --tags "{{tags}}" \
       --extra-vars "@{{config_file}}"
 
+# Install/update spark-http-proxy to the latest version (downloads latest binary +
+# compose.yml and reconfigures *.loc DNS via configure-dns).
+[group('http-proxy')]
+http-proxy-install-update:
+    @just --justfile "{{justfile()}}" provision-tags spark-http-proxy
+
 # User customizations
 import? "~/.config/ajust/100-custom.just"
 

--- a/playbooks/roles/sf-toolbox/files/ajust/justfile
+++ b/playbooks/roles/sf-toolbox/files/ajust/justfile
@@ -87,8 +87,8 @@ provision-tags tags:
       --tags "{{tags}}" \
       --extra-vars "@{{config_file}}"
 
-# Install/update spark-http-proxy to the latest version (downloads latest binary +
-# compose.yml and reconfigures *.loc DNS via configure-dns).
+# Install/update spark-http-proxy to the latest version (updates the git clone,
+# re-links the CLI, and reconfigures *.loc DNS via configure-dns).
 [group('http-proxy')]
 http-proxy-install-update:
     @just --justfile "{{justfile()}}" provision-tags spark-http-proxy

--- a/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
+++ b/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
@@ -1,47 +1,50 @@
 ---
 - name: Install and configure SparkFabrik HTTP Proxy
   tags: [sf-toolbox, packages, spark-http-proxy]
+  vars:
+    proxy_home: "{{ system.home | default(current_home) }}/.local/spark/http-proxy"
+    proxy_src: "{{ proxy_home }}/src"
   block:
     - name: Configure mkcert
       ansible.builtin.command: mkcert -install
       changed_when: false
 
-    - name: Download SparkFabrik HTTP Proxy script
-      ansible.builtin.get_url:
-        url: https://raw.githubusercontent.com/sparkfabrik/http-proxy/refs/heads/main/bin/spark-http-proxy
-        dest: /usr/local/bin/spark-http-proxy
-        mode: "0755"
+    # Install via a git clone + symlink (mirrors the macOS sparkdock mechanism,
+    # but under $HOME). A clone — rather than a standalone downloaded script —
+    # lets `spark-http-proxy self-update` work and keeps the compose file in sync
+    # with the CLI. force/update keep it pinned to the latest main on every run.
+    - name: Clone/update the SparkFabrik HTTP Proxy repository
+      become: true
+      become_user: "{{ system.username | default(current_user) }}"
+      ansible.builtin.git:
+        repo: https://github.com/sparkfabrik/http-proxy.git
+        dest: "{{ proxy_src }}"
+        version: main
+        update: true
         force: true
 
-    - name: Create ~/.local/spark/http-proxy directory
+    - name: Ensure the spark-http-proxy CLI is executable
       ansible.builtin.file:
-        path: "{{ system.home | default(current_home) }}/.local/spark/http-proxy"
-        state: directory
+        path: "{{ proxy_src }}/bin/spark-http-proxy"
         mode: "0755"
-        owner: "{{ system.username | default(current_user) }}"
-        group: "{{ system.username | default(current_user) }}"
 
-    - name: Ensure ~/.local/spark directory ownership
+    # state: link with force replaces a pre-existing standalone file (the old
+    # get_url install) with a symlink into the clone.
+    - name: Symlink spark-http-proxy onto PATH
       ansible.builtin.file:
-        dest: "{{ system.home | default(current_home) }}/.local/spark"
-        owner: "{{ system.username | default(current_user) }}"
-        group: "{{ system.username | default(current_user) }}"
-
-    - name: Download SparkFabrik HTTP Proxy compose file
-      ansible.builtin.get_url:
-        url: https://raw.githubusercontent.com/sparkfabrik/http-proxy/refs/heads/main/bin/compose.yml
-        dest: "{{ system.home | default(current_home) }}/.local/spark/http-proxy/compose.yml"
-        mode: "0644"
-        owner: "{{ system.username | default(current_user) }}"
-        group: "{{ system.username | default(current_user) }}"
-        force: true
-      register: proxy_compose
-
-    - name: Set ownership of spark-http-proxy script
-      ansible.builtin.file:
+        src: "{{ proxy_src }}/bin/spark-http-proxy"
         dest: /usr/local/bin/spark-http-proxy
-        owner: "{{ system.username | default(current_user) }}"
-        group: "{{ system.username | default(current_user) }}"
+        state: link
+        force: true
+
+    # Migration: older installs downloaded a standalone compose.yml here. The CLI
+    # prefers ~/.local/spark/http-proxy/compose.yml over the clone's
+    # src/bin/compose.yml, so a leftover copy would shadow the clone and never
+    # update. Remove it and let the CLI use the clone's compose file.
+    - name: Remove legacy standalone compose.yml superseded by the clone
+      ansible.builtin.file:
+        path: "{{ proxy_home }}/compose.yml"
+        state: absent
 
     - name: Remove legacy docker-dev-dns.conf drop-in superseded by spark-http-proxy
       ansible.builtin.file:
@@ -52,7 +55,7 @@
     - name: Configure system DNS for proxy domains via spark-http-proxy
       ansible.builtin.command: spark-http-proxy configure-dns
       environment:
-        COMPOSE_FILE: "{{ proxy_compose.dest }}"
+        COMPOSE_FILE: "{{ proxy_src }}/bin/compose.yml"
       register: configure_dns
       changed_when: "'succeeded' in configure_dns.stdout"
 

--- a/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
+++ b/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
@@ -9,6 +9,20 @@
       ansible.builtin.command: mkcert -install
       changed_when: false
 
+    # Migration safety: an earlier get_url install left no repo here. If src/
+    # exists but is not a git checkout (leftover junk), remove it so the clone
+    # below starts clean instead of failing on a non-git directory.
+    - name: Check for an existing http-proxy git checkout
+      ansible.builtin.stat:
+        path: "{{ proxy_src }}/.git"
+      register: proxy_src_git
+
+    - name: Remove a non-git http-proxy directory before cloning
+      ansible.builtin.file:
+        path: "{{ proxy_src }}"
+        state: absent
+      when: not proxy_src_git.stat.exists
+
     # Install via a git clone + symlink (mirrors the macOS sparkdock mechanism,
     # but under $HOME). A clone — rather than a standalone downloaded script —
     # lets `spark-http-proxy self-update` work and keeps the compose file in sync

--- a/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
+++ b/playbooks/roles/sf-toolbox/tasks/http-proxy.yml
@@ -11,6 +11,7 @@
         url: https://raw.githubusercontent.com/sparkfabrik/http-proxy/refs/heads/main/bin/spark-http-proxy
         dest: /usr/local/bin/spark-http-proxy
         mode: "0755"
+        force: true
 
     - name: Create ~/.local/spark/http-proxy directory
       ansible.builtin.file:
@@ -33,6 +34,7 @@
         mode: "0644"
         owner: "{{ system.username | default(current_user) }}"
         group: "{{ system.username | default(current_user) }}"
+        force: true
       register: proxy_compose
 
     - name: Set ownership of spark-http-proxy script


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## What

Two related changes to how Linux manages `spark-http-proxy`:

1. **Install via git clone + symlink** (instead of a standalone downloaded script), mirroring the macOS sparkdock mechanism but under `$HOME`.
2. **Add the `http-proxy-install-update` ajust recipe** (group `http-proxy`), for parity with the macOS `sjust` recipe of the same name.

## Why

- The old standalone `get_url` install couldn't use `spark-http-proxy self-update` (it needs a git checkout) and only upgraded conditionally. A clone fixes both: `self-update` works, the compose file stays in sync with the CLI, and re-provisioning deterministically updates to latest `main` (`version: main`, `force`, `update`).
- macOS `sjust` had `http-proxy-install-update` but `ajust` did not, so the same command name now works on both OSes.

## How

- `playbooks/roles/sf-toolbox/tasks/http-proxy.yml`: replace the two `get_url` tasks with an `ansible.builtin.git` clone to `~/.local/spark/http-proxy/src` (as the user) and a `state: link` symlink at `/usr/local/bin/spark-http-proxy`. `configure-dns` now reads the clone's `src/bin/compose.yml`.
- `ajust/justfile`: `http-proxy-install-update` delegates to `provision-tags spark-http-proxy` (no duplicated logic).

### Why keep the `src/` subdirectory

The clone lives in `~/.local/spark/http-proxy/**src**`, not directly in `~/.local/spark/http-proxy`, on purpose:

- The repo's **root `compose.yml` is the dev (build-from-source) compose**. Cloning into `CONFIG_DIR` would put it at the CLI's top compose-discovery path and make it build from source instead of pulling the prod GHCR images.
- `certs/` lives in `CONFIG_DIR`; `src/` keeps the git working tree out of it.

## Migration from the previous standalone install

- The standalone `/usr/local/bin/spark-http-proxy` file is replaced by a symlink into the clone (`state: link`, `force`).
- The leftover `~/.local/spark/http-proxy/compose.yml` is removed — the CLI prefers it over the clone's `src/bin/compose.yml`, so a stale copy would shadow the clone and never update.
- An existing `src/` clone (e.g. from the upstream `install.sh`) is adopted and updated in place.

## Testing

- `just --justfile playbooks/roles/sf-toolbox/files/ajust/justfile --list` parses; the recipe shows under `[http-proxy]`.
- `http-proxy.yml` validates as YAML.

Closes #227
Closes #229

Supersedes #228 (the `force: true` band-aid on the old `get_url` install).