### PR TITLE
feat(sf-toolbox): enable the Claude gh skill gate automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Enable the Claude Code `gh` skill gate automatically in the `sf-toolbox` role by running the sparkdock-installed `claude-gh-gate.py enable` (blocks raw `gh` commands until the `gh` skill is loaded), with a fallback warning to run `ajust claude-gh-gate-enable` manually if the sparkdock script is missing. Mirrors the existing caveman/rtk setup pattern and the macOS sparkdock provisioning.
 - Install `spark-http-proxy` on Linux via a git clone + symlink (under `~/.local/spark/http-proxy/src`) instead of a standalone downloaded script, mirroring the macOS sparkdock mechanism. This makes `spark-http-proxy self-update` work, keeps the compose file in sync with the CLI, and deterministically updates to the latest `main` on every provision. Migrates existing installs by replacing the standalone CLI file with a symlink and removing the now-stale standalone `compose.yml` that would otherwise shadow the clone
 - Added `http-proxy-install-update` ajust recipe (group `http-proxy`) for parity with macOS sjust; updates `spark-http-proxy` via the CLI's own `self-update` (git-pulls the clone it was installed from), so it needs no provisioner checkout or config
 - Fixed the `provision-tags` ajust recipe default `provisioner_path` (`$HOME/provisioner` → `/opt/archlinux-provisioner`, where `bootstrap.sh`/`install.linux` install the provisioner) so provisioner-tag recipes find the checkout without manually setting `AJUST_PROVISIONER_PATH`

--- a/playbooks/roles/sf-toolbox/tasks/claude-gh-gate.yml
+++ b/playbooks/roles/sf-toolbox/tasks/claude-gh-gate.yml
@@ -1,0 +1,28 @@
+---
+- name: Configure Claude gh skill gate
+  tags: [sf-toolbox, ai, claude-gh-gate]
+  block:
+    - name: Check if the Claude gh-gate script exists
+      become: true
+      become_user: "{{ system.username | default(current_user) }}"
+      ansible.builtin.stat:
+        path: "{{ sparkdock.path | default(sparkdock_default_path) }}/sjust/scripts/claude-gh-gate.py"
+      register: claude_gh_gate_script
+
+    - name: Enable the Claude gh skill gate
+      become: true
+      become_user: "{{ system.username | default(current_user) }}"
+      ansible.builtin.command: "python3 {{ sparkdock.path | default(sparkdock_default_path) }}/sjust/scripts/claude-gh-gate.py enable"
+      environment:
+        HOME: "{{ system.home | default(current_home) }}"
+      register: claude_gh_gate_output
+      changed_when: "'already enabled' not in claude_gh_gate_output.stdout"
+      when:
+        - claude_gh_gate_script.stat.exists
+
+    - name: Warn user to manually enable the Claude gh-gate
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Automatic Claude gh-gate configuration was not possible.
+          Please run `ajust claude-gh-gate-enable` manually to complete the setup.
+      when: not claude_gh_gate_script.stat.exists

--- a/playbooks/roles/sf-toolbox/tasks/main.yml
+++ b/playbooks/roles/sf-toolbox/tasks/main.yml
@@ -25,3 +25,6 @@
 
 - name: Configure caveman
   import_tasks: caveman.yml
+
+- name: Configure Claude gh skill gate
+  import_tasks: claude-gh-gate.yml


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## What

Enable the Claude Code `gh` skill gate by default on Arch, in the `sf-toolbox` role, matching the macOS sparkdock provisioning.

## Why

sparkdock ([sparkfabrik/sparkdock#526](https://github.com/sparkfabrik/sparkdock/pull/526)) ships a Claude Code `PreToolUse` hook (`claude-gh-gate.py`) that blocks raw `gh` commands until the `gh` skill is loaded, so agents pick up the skill's auth handling, structured output, and SparkFabrik conventions. On macOS it is enabled during provisioning; this brings Arch to parity.

## Changes

- New `playbooks/roles/sf-toolbox/tasks/claude-gh-gate.yml`: stat the sparkdock-installed `sjust/scripts/claude-gh-gate.py`, run `python3 … enable` as the target user (with `HOME` set so it writes to the user's `~/.claude/settings.json`), idempotent `changed_when` (only "changed" when not already enabled), and a fallback warning to run `ajust claude-gh-gate-enable` if the script is missing.
- Wire it into `roles/sf-toolbox/tasks/main.yml` after the caveman task.
- CHANGELOG entry.

It mirrors the existing `caveman.yml` / `rtk.yml` setup tasks (run a sparkdock script, guard on its presence), so it depends on the `sparkdock` role having cloned the checkout, exactly like those.

## Verification

- `ansible-playbook --syntax-check playbooks/sf-toolbox.yml` passes; YAML valid.
- The underlying script and its `enable` path were validated end to end via `ajust` on Arch (enable/disable round-trip, RTK hook preserved, mode 600 kept, runtime gate blocks `gh` until the skill loads).

Tags: `sf-toolbox`, `ai`, `claude-gh-gate` (selective run via `TAGS=claude-gh-gate`).


___

### **PR Type**
Enhancement


___

### **Description**
- Add automatic Claude Code `gh` skill gate enablement in `sf-toolbox` role

- New `claude-gh-gate.yml` task: stat script, run enable, warn if missing

- Wired into `main.yml` after caveman task; mirrors caveman/rtk pattern

- CHANGELOG updated with feature description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["main.yml"] -- "import_tasks" --> B["claude-gh-gate.yml"]
  B -- "stat" --> C["claude-gh-gate.py\n(sparkdock checkout)"]
  C -- "exists" --> D["python3 claude-gh-gate.py enable"]
  C -- "missing" --> E["Warn: run ajust claude-gh-gate-enable"]
  D -- "writes" --> F["~/.claude/settings.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Claude gh skill gate feature in CHANGELOG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry describing the new Claude Code <code>gh</code> skill gate <br>auto-enablement feature<br> <li> Documents fallback warning behavior and mirrors macOS sparkdock <br>provisioning parity</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/233/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-gh-gate.yml</strong><dd><code>Add Claude gh skill gate configuration task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/claude-gh-gate.yml

<ul><li>New task file to configure the Claude Code <code>gh</code> skill gate<br> <li> Stats the sparkdock-installed <code>claude-gh-gate.py</code> script before running <br>it<br> <li> Runs <code>python3 claude-gh-gate.py enable</code> as the target user with <code>HOME</code> set <br>for correct <code>~/.claude/settings.json</code> placement<br> <li> Idempotent via <code>changed_when</code> checking for "already enabled" in stdout; <br>warns user to run manually if script is missing</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/233/files#diff-a92b2e8cc73dd3e6e20a1b767a58fd8d7654c558697758e1f16de043eddef368">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.yml</strong><dd><code>Wire claude-gh-gate task into sf-toolbox main playbook</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/main.yml

- Added import of `claude-gh-gate.yml` task after the caveman task


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/233/files#diff-c8105664846b49ed10cd80366133e828343729d603acd55cdfe248515ad596b3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

