### PR TITLE
fix(sf-toolbox): disable Homebrew 6 Linux sandbox on Debian/Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `sf-toolbox` Homebrew package installs failing on Debian/Ubuntu with "Bubblewrap is installed but cannot create a rootless sandbox" when building source-only formulae (e.g. `opencode`). Homebrew 6.0 enables a Bubblewrap build sandbox on Linux by default, which fails on distros that restrict unprivileged user namespaces (Ubuntu 24.04+ AppArmor). The brew install tasks now set `HOMEBREW_NO_SANDBOX_LINUX=1`, and the managed Homebrew shellenv (`/etc/profile.d/homebrew.sh`, `~/.zshrc`, `~/.bashrc`) exports it so manual `brew` commands work too, without relaxing kernel or AppArmor hardening
 - Fixed `sf-toolbox` failing with "PyYAML is not installed" when a Homebrew `python3` shadows the system interpreter on `PATH`; the installer now selects a `python3` that has PyYAML (preferring `/usr/bin/python3`) for the toolbox package parser
 - Fixed `sf-toolbox` npm packages (e.g. `@fission-ai/openspec`) never upgrading after first install by switching the Arch and Debian/Ubuntu npm install tasks from `state: present` to `state: latest`, matching the existing Homebrew behavior
 - Fixed rtk not detected by sf-toolbox conflict system; added `rtk` to `toolbox.detect` list and `is_sf_managed()`, removed redundant per-role `which -a` detection that didn't feed into the conflict resolver

--- a/playbooks/roles/sf-toolbox/tasks/homebrew.yml
+++ b/playbooks/roles/sf-toolbox/tasks/homebrew.yml
@@ -38,6 +38,9 @@
           # Homebrew (linuxbrew) PATH integration
           if [ -d /home/linuxbrew/.linuxbrew ]; then
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            # Homebrew 6.0's Linux build sandbox fails where unprivileged user
+            # namespaces are restricted (e.g. Ubuntu 24.04+ AppArmor); disable it.
+            export HOMEBREW_NO_SANDBOX_LINUX=1
           fi
 
     - name: Check if ~/.zshrc exists
@@ -55,6 +58,9 @@
           # Homebrew (linuxbrew) — managed by sf-toolbox
           if [ -d /home/linuxbrew/.linuxbrew ]; then
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            # Homebrew 6.0's Linux build sandbox fails where unprivileged user
+            # namespaces are restricted (e.g. Ubuntu 24.04+ AppArmor); disable it.
+            export HOMEBREW_NO_SANDBOX_LINUX=1
           fi
         mode: "0644"
       when: user_zshrc.stat.exists
@@ -74,6 +80,9 @@
           # Homebrew (linuxbrew) — managed by sf-toolbox
           if [ -d /home/linuxbrew/.linuxbrew ]; then
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+            # Homebrew 6.0's Linux build sandbox fails where unprivileged user
+            # namespaces are restricted (e.g. Ubuntu 24.04+ AppArmor); disable it.
+            export HOMEBREW_NO_SANDBOX_LINUX=1
           fi
         mode: "0644"
       when: user_bashrc.stat.exists

--- a/playbooks/roles/sf-toolbox/tasks/packages.yml
+++ b/playbooks/roles/sf-toolbox/tasks/packages.yml
@@ -50,6 +50,12 @@
         name: "{{ toolbox.debian.homebrew }}"
         state: latest
         path: /home/linuxbrew/.linuxbrew/bin
+      environment:
+        # Homebrew 6.0 enables a Bubblewrap build sandbox on Linux by default,
+        # which fails on distros that restrict unprivileged user namespaces
+        # (e.g. Ubuntu 24.04+ AppArmor). Disable it so source builds (opencode)
+        # succeed without relaxing kernel/AppArmor hardening.
+        HOMEBREW_NO_SANDBOX_LINUX: "1"
       when: ansible_facts['os_family'] == "Debian"
 
     # Migration: uninstall claude-code (stable) before installing claude-code@latest
@@ -70,6 +76,8 @@
         name: "{{ toolbox.debian.homebrew_casks }}"
         state: latest
         path: /home/linuxbrew/.linuxbrew/bin
+      environment:
+        HOMEBREW_NO_SANDBOX_LINUX: "1"
       when:
         - ansible_facts['os_family'] == "Debian"
         - toolbox.debian.homebrew_casks | default([]) | length > 0


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

Provisioning fails on Debian/Ubuntu at `Install homebrew packages`:

```
fatal: [localhost]: FAILED! => Formula opencode (1.17.7)
Error: Bubblewrap is installed but cannot create a rootless sandbox.
Homebrew's Linux sandbox requires rootless Bubblewrap and unprivileged user namespaces.
```

Homebrew 6.0 (June 2026) enabled a [Bubblewrap build sandbox on Linux](https://github.com/Homebrew/brew/pull/22240) by default. It relies on unprivileged user namespaces, which Ubuntu 24.04+ restricts via AppArmor (`kernel.apparmor_restrict_unprivileged_userns=1`). Any source-only formula build then fails to create the sandbox.

`opencode` comes from `anomalyco/tap` and has no bottle, so it builds from source and trips the sandbox. The bottled formulae in the list (just, gum, gh, glab, mkcert, gopls, ripgrep, openspec) are unaffected.

## Fix

Set `HOMEBREW_NO_SANDBOX_LINUX=1` (the documented override for `HOMEBREW_SANDBOX_LINUX`):

- on the `community.general.homebrew` and `community.general.homebrew_cask` install tasks in `packages.yml`
- exported from the managed Homebrew shellenv blocks in `homebrew.yml` (`/etc/profile.d/homebrew.sh`, `~/.zshrc`, `~/.bashrc`) so a later manual `brew install`/`brew upgrade` also works

This scopes the change to Homebrew builds only. It does not relax kernel or AppArmor hardening system-wide (the alternative of setting `kernel.apparmor_restrict_unprivileged_userns=0` would re-open unprivileged user namespaces for all processes).

## Verification

On a Debian/Ubuntu host:

```
TAGS=packages CONFIG=./config/default.yaml make local-install-tags
brew list opencode      # installed
```


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Homebrew 6.0 Linux sandbox failure on Debian/Ubuntu systems

- Set `HOMEBREW_NO_SANDBOX_LINUX=1` on brew install/cask tasks in `packages.yml`

- Export `HOMEBREW_NO_SANDBOX_LINUX=1` in shell profiles (`/etc/profile.d/homebrew.sh`, `~/.zshrc`, `~/.bashrc`)

- Document fix in `CHANGELOG.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Homebrew 6.0\nLinux Bubblewrap Sandbox"] -- "fails on" --> B["Ubuntu 24.04+\nAppArmor restriction"]
  B -- "breaks" --> C["source-only formula builds\n(e.g. opencode)"]
  D["HOMEBREW_NO_SANDBOX_LINUX=1"] -- "set in" --> E["packages.yml\nhomebrew install tasks"]
  D -- "exported in" --> F["shell profiles\n(/etc/profile.d, .zshrc, .bashrc)"]
  E -- "fixes" --> C
  F -- "fixes" --> G["manual brew commands"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Homebrew sandbox fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting the Homebrew 6.0 Linux sandbox fix for <br>Debian/Ubuntu</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/235/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>homebrew.yml</strong><dd><code>Export sandbox disable flag in all shell profiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/homebrew.yml

<ul><li>Added <code>export HOMEBREW_NO_SANDBOX_LINUX=1</code> to <code>/etc/profile.d/homebrew.sh</code> <br>shellenv block<br> <li> Added <code>export HOMEBREW_NO_SANDBOX_LINUX=1</code> to <code>~/.zshrc</code> managed shellenv <br>block<br> <li> Added <code>export HOMEBREW_NO_SANDBOX_LINUX=1</code> to <code>~/.bashrc</code> managed shellenv <br>block<br> <li> Each addition includes an explanatory comment about Homebrew 6.0 and <br>AppArmor restrictions</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/235/files#diff-6a424139e4ee18cdd676b3424d54d5699d2f32a18d200ff411a64a0029c226dc">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>packages.yml</strong><dd><code>Set sandbox disable env var on brew install tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/packages.yml

<ul><li>Added <code>environment: HOMEBREW_NO_SANDBOX_LINUX: "1"</code> to the Homebrew <br>packages install task for Debian/Ubuntu<br> <li> Added <code>environment: HOMEBREW_NO_SANDBOX_LINUX: "1"</code> to the Homebrew <br>casks install task for Debian/Ubuntu<br> <li> Includes explanatory comment about Bubblewrap sandbox failure on <br>restricted distros</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/235/files#diff-2daf5a6d8af37c14c3c47c61a8ebfea4c114991eaf7312d01e822be245cc0fcf">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

