### PR TITLE
fix(sf-toolbox): update gcloud components on every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `sf-toolbox` now runs `gcloud components update` on every provisioning pass, so an existing Google Cloud SDK in `/opt/google-cloud-sdk` is kept current instead of staying pinned at the version installed on first provision
 - Delegated `*.loc` systemd-resolved configuration to the `spark-http-proxy` CLI and removed the bespoke `docker` role drop-in (`docker-dev-dns.conf`, `172.17.0.1:19322`); the CLI now writes `http-proxy.conf` (`127.0.0.1:19322`). Legacy `~docker`/dnsdock routing is no longer configured
 - Replaced the obsolete Python `yq` package (pacman) with `go-yq`, the mikefarah Go yq v4 (`extra` repo); the old `yq` is now removed first since the two packages conflict
 - Homebrew formulae, casks, and rtk now install with `state: latest` so packages upgrade on every run

--- a/playbooks/roles/sf-toolbox/tasks/gcloud.yml
+++ b/playbooks/roles/sf-toolbox/tasks/gcloud.yml
@@ -35,6 +35,13 @@
       changed_when: false
       when: gcloud_installed.stat.exists
 
+    - name: Update Google Cloud SDK components
+      ansible.builtin.command:
+        cmd: /opt/google-cloud-sdk/bin/gcloud components update --quiet
+      register: gcloud_components_update
+      changed_when: "'All components are up to date' not in gcloud_components_update.stderr"
+      when: gcloud_installed.stat.exists
+
     - name: Install gke-gcloud-auth-plugin component
       ansible.builtin.command:
         cmd: /opt/google-cloud-sdk/bin/gcloud components install gke-gcloud-auth-plugin --quiet


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #239

## Problem

Every Google Cloud SDK task in `playbooks/roles/sf-toolbox/tasks/gcloud.yml` that could change the installed version was gated on `when: not gcloud_installed.stat.exists`. Once `/opt/google-cloud-sdk/bin/gcloud` existed, the download, extract, and `install.sh` tasks were all skipped, so the SDK stayed pinned at whatever version was current when the machine was first provisioned.

Nothing else picked up the slack: `google-cloud-cli` and `google-cloud-cli-gke-gcloud-auth-plugin` are in the role's `remove:` list in `vars/main.yml`, so pacman does not manage it either.

Observed on a developer machine: `566.0.0` installed against `577.0.0` in the rapid channel.

## Change

Adds one task to `gcloud.yml`:

```yaml
- name: Update Google Cloud SDK components
  ansible.builtin.command:
    cmd: /opt/google-cloud-sdk/bin/gcloud components update --quiet
  register: gcloud_components_update
  changed_when: "'All components are up to date' not in gcloud_components_update.stderr"
  when: gcloud_installed.stat.exists
```

## Notes on the implementation

**Placement.** The task sits immediately before the existing `gke-gcloud-auth-plugin` install, so the plugin install runs against an already-current SDK and does not hit a version-mismatch prompt.

**Idempotency.** `gcloud` writes the literal string `All components are up to date.` to stderr when there is nothing to do (`lib/googlecloudsdk/core/updater/update_manager.py:1012`, via `log.status`). This is the same `changed_when` idiom the adjacent `gke-gcloud-auth-plugin` task already uses.

**Why gated on `stat.exists`.** A fresh install pulls the tarball from the rapid channel and is therefore already latest, so running the update on a first provision would be a pure round trip. This mirrors the existing "Disable gcloud usage reporting" task, which is gated the same way.

**Privileges.** `/opt/google-cloud-sdk` is `root:root` and the playbook runs under `sudo`. The task deliberately sets no `become_user`, so it runs as root and can write to the install directory.

## Tradeoff worth flagging on review

On a badly stale SDK this is a large download, and the task is fatal on failure, so a flaky network turns a provisioning run into a hard failure where it previously kept working with an old `gcloud`. This matches the existing exposure of the `gke-gcloud-auth-plugin` task on the next line, which is why it was left fatal rather than wrapped in `failed_when: false`. Happy to soften it to a warning if reviewers prefer.

## Verification

- `ansible-playbook playbooks/sf-toolbox.yml --syntax-check` passes.
- The `All components are up to date` string was confirmed against the vendored gcloud source rather than assumed.

The macOS counterpart is sparkfabrik/sparkdock#569.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `gcloud components update` task to keep existing Google Cloud SDK installations current

- Task is gated on SDK already existing and placed before `gke-gcloud-auth-plugin` install

- Idempotency handled via `changed_when` checking stderr for "All components are up to date"

- Updated `CHANGELOG.md` with entry describing the new update behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gcloud installed?"] -- "yes" --> B["Run gcloud components update --quiet"]
  B -- "components updated" --> C["Install gke-gcloud-auth-plugin"]
  A -- "no" --> D["Skip update, fresh install is already latest"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gcloud.yml</strong><dd><code>Add gcloud components update task for existing installs</code>&nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/gcloud.yml

<ul><li>Added new task "Update Google Cloud SDK components" that runs <code>gcloud </code><br><code>components update --quiet</code><br> <li> Task is gated on <code>gcloud_installed.stat.exists</code> to skip on fresh <br>installs<br> <li> Uses <code>changed_when</code> with stderr check for idempotency, matching the <br>adjacent plugin task idiom<br> <li> Placed before <code>gke-gcloud-auth-plugin</code> install to avoid version-mismatch <br>prompts</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/240/files#diff-e2ffb23cb5b425f1587a215e74c41224a5be67adf1314ff330297198a1ab5dd4">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document gcloud auto-update in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry under "Changed" section documenting that <code>gcloud </code><br><code>components update</code> now runs on every provisioning pass</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/240/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/z-ai/glm-5.2